### PR TITLE
feat(core): add centralized configuration management system

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -1,0 +1,45 @@
+{
+  "orchestrator": {
+    "shutdownTimeout": 2000,
+    "processSpawnRetries": 3,
+    "lockFileTimeout": 5000,
+    "watchDebounce": 100,
+    "watchStabilityThreshold": 200,
+    "watchPollInterval": 50
+  },
+  "taskRunner": {
+    "maxRefinementAttempts": 2,
+    "stageTimeout": 300000,
+    "llmRequestTimeout": 60000
+  },
+  "llm": {
+    "defaultProvider": "openai",
+    "defaultModel": "gpt-5-chat-latest",
+    "maxConcurrency": 5,
+    "retryMaxAttempts": 3,
+    "retryBackoffMs": 1000
+  },
+  "ui": {
+    "port": 3000,
+    "host": "localhost",
+    "heartbeatInterval": 30000,
+    "maxRecentChanges": 10
+  },
+  "paths": {
+    "dataDir": "pipeline-data",
+    "configDir": "pipeline-config",
+    "pendingDir": "pending",
+    "currentDir": "current",
+    "completeDir": "complete"
+  },
+  "validation": {
+    "seedNameMinLength": 1,
+    "seedNameMaxLength": 100,
+    "seedNamePattern": "^[a-zA-Z0-9-_]+$"
+  },
+  "logging": {
+    "level": "info",
+    "format": "json",
+    "destination": "stdout"
+  }
+}

--- a/config.schema.json
+++ b/config.schema.json
@@ -1,0 +1,220 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Prompt Orchestration Pipeline Configuration",
+  "description": "Configuration schema for the Prompt Orchestration Pipeline",
+  "type": "object",
+  "properties": {
+    "orchestrator": {
+      "type": "object",
+      "description": "Orchestrator configuration",
+      "properties": {
+        "shutdownTimeout": {
+          "type": "integer",
+          "description": "Timeout in milliseconds for graceful shutdown",
+          "minimum": 100,
+          "default": 2000
+        },
+        "processSpawnRetries": {
+          "type": "integer",
+          "description": "Number of retries for process spawn failures",
+          "minimum": 0,
+          "default": 3
+        },
+        "lockFileTimeout": {
+          "type": "integer",
+          "description": "Timeout in milliseconds for lock file acquisition",
+          "minimum": 100,
+          "default": 5000
+        },
+        "watchDebounce": {
+          "type": "integer",
+          "description": "Debounce time in milliseconds for file watcher",
+          "minimum": 0,
+          "default": 100
+        },
+        "watchStabilityThreshold": {
+          "type": "integer",
+          "description": "Stability threshold in milliseconds for file watcher",
+          "minimum": 0,
+          "default": 200
+        },
+        "watchPollInterval": {
+          "type": "integer",
+          "description": "Poll interval in milliseconds for file watcher",
+          "minimum": 10,
+          "default": 50
+        }
+      }
+    },
+    "taskRunner": {
+      "type": "object",
+      "description": "Task runner configuration",
+      "properties": {
+        "maxRefinementAttempts": {
+          "type": "integer",
+          "description": "Maximum number of refinement attempts for validation failures",
+          "minimum": 0,
+          "default": 2
+        },
+        "stageTimeout": {
+          "type": "integer",
+          "description": "Timeout in milliseconds for each pipeline stage",
+          "minimum": 1000,
+          "default": 300000
+        },
+        "llmRequestTimeout": {
+          "type": "integer",
+          "description": "Timeout in milliseconds for LLM requests",
+          "minimum": 1000,
+          "default": 60000
+        }
+      }
+    },
+    "llm": {
+      "type": "object",
+      "description": "LLM configuration",
+      "properties": {
+        "defaultProvider": {
+          "type": "string",
+          "description": "Default LLM provider",
+          "enum": ["openai", "deepseek", "anthropic"],
+          "default": "openai"
+        },
+        "defaultModel": {
+          "type": "string",
+          "description": "Default model to use",
+          "default": "gpt-5-chat-latest"
+        },
+        "maxConcurrency": {
+          "type": "integer",
+          "description": "Maximum concurrent LLM requests",
+          "minimum": 1,
+          "default": 5
+        },
+        "retryMaxAttempts": {
+          "type": "integer",
+          "description": "Maximum retry attempts for failed LLM requests",
+          "minimum": 0,
+          "default": 3
+        },
+        "retryBackoffMs": {
+          "type": "integer",
+          "description": "Initial backoff time in milliseconds for retries",
+          "minimum": 100,
+          "default": 1000
+        }
+      }
+    },
+    "ui": {
+      "type": "object",
+      "description": "UI server configuration",
+      "properties": {
+        "port": {
+          "type": "integer",
+          "description": "UI server port",
+          "minimum": 1,
+          "maximum": 65535,
+          "default": 3000
+        },
+        "host": {
+          "type": "string",
+          "description": "UI server host",
+          "default": "localhost"
+        },
+        "heartbeatInterval": {
+          "type": "integer",
+          "description": "Heartbeat interval in milliseconds",
+          "minimum": 1000,
+          "default": 30000
+        },
+        "maxRecentChanges": {
+          "type": "integer",
+          "description": "Maximum number of recent changes to track",
+          "minimum": 1,
+          "default": 10
+        }
+      }
+    },
+    "paths": {
+      "type": "object",
+      "description": "Path configuration",
+      "properties": {
+        "root": {
+          "type": "string",
+          "description": "Root directory for pipeline operations"
+        },
+        "dataDir": {
+          "type": "string",
+          "description": "Directory for pipeline data",
+          "default": "pipeline-data"
+        },
+        "configDir": {
+          "type": "string",
+          "description": "Directory for pipeline configuration",
+          "default": "pipeline-config"
+        },
+        "pendingDir": {
+          "type": "string",
+          "description": "Directory for pending jobs",
+          "default": "pending"
+        },
+        "currentDir": {
+          "type": "string",
+          "description": "Directory for current jobs",
+          "default": "current"
+        },
+        "completeDir": {
+          "type": "string",
+          "description": "Directory for completed jobs",
+          "default": "complete"
+        }
+      }
+    },
+    "validation": {
+      "type": "object",
+      "description": "Validation configuration",
+      "properties": {
+        "seedNameMinLength": {
+          "type": "integer",
+          "description": "Minimum length for seed names",
+          "minimum": 1,
+          "default": 1
+        },
+        "seedNameMaxLength": {
+          "type": "integer",
+          "description": "Maximum length for seed names",
+          "minimum": 1,
+          "default": 100
+        },
+        "seedNamePattern": {
+          "type": "string",
+          "description": "Regex pattern for seed names",
+          "default": "^[a-zA-Z0-9-_]+$"
+        }
+      }
+    },
+    "logging": {
+      "type": "object",
+      "description": "Logging configuration",
+      "properties": {
+        "level": {
+          "type": "string",
+          "description": "Log level",
+          "enum": ["debug", "info", "warn", "error"],
+          "default": "info"
+        },
+        "format": {
+          "type": "string",
+          "description": "Log format",
+          "enum": ["json", "text"],
+          "default": "json"
+        },
+        "destination": {
+          "type": "string",
+          "description": "Log destination (stdout or file path)",
+          "default": "stdout"
+        }
+      }
+    }
+  }
+}

--- a/src/core/config.js
+++ b/src/core/config.js
@@ -1,0 +1,344 @@
+/**
+ * Centralized configuration management for Prompt Orchestration Pipeline
+ *
+ * This module provides a single source of truth for all configuration values,
+ * supporting both environment variables and config file overrides.
+ */
+
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+/**
+ * Default configuration values
+ * These can be overridden by environment variables or config file
+ */
+export const defaultConfig = {
+  orchestrator: {
+    shutdownTimeout: 2000,
+    processSpawnRetries: 3,
+    lockFileTimeout: 5000,
+    watchDebounce: 100,
+    watchStabilityThreshold: 200,
+    watchPollInterval: 50,
+  },
+  taskRunner: {
+    maxRefinementAttempts: 2,
+    stageTimeout: 300000,
+    llmRequestTimeout: 60000,
+  },
+  llm: {
+    defaultProvider: "openai",
+    defaultModel: "gpt-5-chat-latest",
+    maxConcurrency: 5,
+    retryMaxAttempts: 3,
+    retryBackoffMs: 1000,
+  },
+  ui: {
+    port: 3000,
+    host: "localhost",
+    heartbeatInterval: 30000,
+    maxRecentChanges: 10,
+  },
+  paths: {
+    root: process.env.PO_ROOT || process.cwd(),
+    dataDir: "pipeline-data",
+    configDir: "pipeline-config",
+    pendingDir: "pending",
+    currentDir: "current",
+    completeDir: "complete",
+  },
+  validation: {
+    seedNameMinLength: 1,
+    seedNameMaxLength: 100,
+    seedNamePattern: "^[a-zA-Z0-9-_]+$",
+  },
+  logging: {
+    level: "info",
+    format: "json",
+    destination: "stdout",
+  },
+};
+
+/**
+ * Current loaded configuration
+ * Initialized with defaults, then overridden by environment and config file
+ */
+let currentConfig = null;
+
+/**
+ * Load configuration from environment variables
+ * Environment variables take precedence over defaults
+ */
+function loadFromEnvironment(config) {
+  const envConfig = { ...config };
+
+  // Orchestrator settings
+  if (process.env.PO_SHUTDOWN_TIMEOUT) {
+    envConfig.orchestrator.shutdownTimeout = parseInt(
+      process.env.PO_SHUTDOWN_TIMEOUT,
+      10
+    );
+  }
+  if (process.env.PO_PROCESS_SPAWN_RETRIES) {
+    envConfig.orchestrator.processSpawnRetries = parseInt(
+      process.env.PO_PROCESS_SPAWN_RETRIES,
+      10
+    );
+  }
+  if (process.env.PO_LOCK_FILE_TIMEOUT) {
+    envConfig.orchestrator.lockFileTimeout = parseInt(
+      process.env.PO_LOCK_FILE_TIMEOUT,
+      10
+    );
+  }
+  if (process.env.PO_WATCH_DEBOUNCE) {
+    envConfig.orchestrator.watchDebounce = parseInt(
+      process.env.PO_WATCH_DEBOUNCE,
+      10
+    );
+  }
+
+  // Task runner settings
+  if (process.env.PO_MAX_REFINEMENT_ATTEMPTS) {
+    envConfig.taskRunner.maxRefinementAttempts = parseInt(
+      process.env.PO_MAX_REFINEMENT_ATTEMPTS,
+      10
+    );
+  }
+  if (process.env.PO_STAGE_TIMEOUT) {
+    envConfig.taskRunner.stageTimeout = parseInt(
+      process.env.PO_STAGE_TIMEOUT,
+      10
+    );
+  }
+  if (process.env.PO_LLM_REQUEST_TIMEOUT) {
+    envConfig.taskRunner.llmRequestTimeout = parseInt(
+      process.env.PO_LLM_REQUEST_TIMEOUT,
+      10
+    );
+  }
+
+  // LLM settings
+  if (process.env.PO_DEFAULT_PROVIDER) {
+    envConfig.llm.defaultProvider = process.env.PO_DEFAULT_PROVIDER;
+  }
+  if (process.env.PO_DEFAULT_MODEL) {
+    envConfig.llm.defaultModel = process.env.PO_DEFAULT_MODEL;
+  }
+  if (process.env.PO_MAX_CONCURRENCY) {
+    envConfig.llm.maxConcurrency = parseInt(process.env.PO_MAX_CONCURRENCY, 10);
+  }
+
+  // UI settings
+  if (process.env.PO_UI_PORT || process.env.PORT) {
+    envConfig.ui.port = parseInt(
+      process.env.PO_UI_PORT || process.env.PORT,
+      10
+    );
+  }
+  if (process.env.PO_UI_HOST) {
+    envConfig.ui.host = process.env.PO_UI_HOST;
+  }
+  if (process.env.PO_HEARTBEAT_INTERVAL) {
+    envConfig.ui.heartbeatInterval = parseInt(
+      process.env.PO_HEARTBEAT_INTERVAL,
+      10
+    );
+  }
+
+  // Path settings
+  if (process.env.PO_ROOT) {
+    envConfig.paths.root = process.env.PO_ROOT;
+  }
+  if (process.env.PO_DATA_DIR) {
+    envConfig.paths.dataDir = process.env.PO_DATA_DIR;
+  }
+  if (process.env.PO_CONFIG_DIR) {
+    envConfig.paths.configDir = process.env.PO_CONFIG_DIR;
+  }
+
+  // Logging settings
+  if (process.env.PO_LOG_LEVEL) {
+    envConfig.logging.level = process.env.PO_LOG_LEVEL;
+  }
+  if (process.env.PO_LOG_FORMAT) {
+    envConfig.logging.format = process.env.PO_LOG_FORMAT;
+  }
+  if (process.env.PO_LOG_DESTINATION) {
+    envConfig.logging.destination = process.env.PO_LOG_DESTINATION;
+  }
+
+  return envConfig;
+}
+
+/**
+ * Deep merge two configuration objects
+ */
+function deepMerge(target, source) {
+  const result = { ...target };
+
+  for (const key in source) {
+    if (
+      source[key] &&
+      typeof source[key] === "object" &&
+      !Array.isArray(source[key])
+    ) {
+      result[key] = deepMerge(target[key] || {}, source[key]);
+    } else {
+      result[key] = source[key];
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Load configuration from a JSON file
+ * Returns null if file doesn't exist
+ */
+async function loadFromFile(configPath) {
+  try {
+    const content = await fs.readFile(configPath, "utf8");
+    return JSON.parse(content);
+  } catch (error) {
+    if (error.code === "ENOENT") {
+      return null;
+    }
+    throw new Error(
+      `Failed to load config file ${configPath}: ${error.message}`
+    );
+  }
+}
+
+/**
+ * Validate configuration values
+ * Throws if configuration is invalid
+ */
+function validateConfig(config) {
+  const errors = [];
+
+  // Validate numeric values are positive
+  if (config.orchestrator.shutdownTimeout <= 0) {
+    errors.push("orchestrator.shutdownTimeout must be positive");
+  }
+  if (config.orchestrator.processSpawnRetries < 0) {
+    errors.push("orchestrator.processSpawnRetries must be non-negative");
+  }
+  if (config.taskRunner.maxRefinementAttempts < 0) {
+    errors.push("taskRunner.maxRefinementAttempts must be non-negative");
+  }
+  if (config.llm.maxConcurrency <= 0) {
+    errors.push("llm.maxConcurrency must be positive");
+  }
+  if (config.ui.port < 1 || config.ui.port > 65535) {
+    errors.push("ui.port must be between 1 and 65535");
+  }
+
+  // Validate provider
+  const validProviders = ["openai", "deepseek", "anthropic"];
+  if (!validProviders.includes(config.llm.defaultProvider)) {
+    errors.push(
+      `llm.defaultProvider must be one of: ${validProviders.join(", ")}`
+    );
+  }
+
+  // Validate log level
+  const validLogLevels = ["debug", "info", "warn", "error"];
+  if (!validLogLevels.includes(config.logging.level)) {
+    errors.push(`logging.level must be one of: ${validLogLevels.join(", ")}`);
+  }
+
+  if (errors.length > 0) {
+    throw new Error(
+      `Configuration validation failed:\n${errors.map((e) => `  - ${e}`).join("\n")}`
+    );
+  }
+}
+
+/**
+ * Initialize and load configuration
+ *
+ * Priority order (highest to lowest):
+ * 1. Environment variables
+ * 2. Config file (if provided)
+ * 3. Default values
+ *
+ * @param {Object} options - Configuration options
+ * @param {string} options.configPath - Path to config file (optional)
+ * @param {boolean} options.validate - Whether to validate config (default: true)
+ * @returns {Object} Loaded configuration
+ */
+export async function loadConfig(options = {}) {
+  const { configPath, validate = true } = options;
+
+  // Start with defaults
+  let config = JSON.parse(JSON.stringify(defaultConfig));
+
+  // Load from config file if provided
+  if (configPath) {
+    const fileConfig = await loadFromFile(configPath);
+    if (fileConfig) {
+      config = deepMerge(config, fileConfig);
+    }
+  }
+
+  // Override with environment variables
+  config = loadFromEnvironment(config);
+
+  // Validate if requested
+  if (validate) {
+    validateConfig(config);
+  }
+
+  // Cache the loaded config
+  currentConfig = config;
+
+  return config;
+}
+
+/**
+ * Get the current configuration
+ * Loads default config if not already loaded
+ *
+ * @returns {Object} Current configuration
+ */
+export function getConfig() {
+  if (!currentConfig) {
+    // Load defaults synchronously for first access
+    currentConfig = loadFromEnvironment(
+      JSON.parse(JSON.stringify(defaultConfig))
+    );
+  }
+  return currentConfig;
+}
+
+/**
+ * Reset configuration to defaults
+ * Useful for testing
+ */
+export function resetConfig() {
+  currentConfig = null;
+}
+
+/**
+ * Get a specific configuration value by path
+ *
+ * @param {string} path - Dot-separated path (e.g., "orchestrator.shutdownTimeout")
+ * @param {*} defaultValue - Default value if path not found
+ * @returns {*} Configuration value
+ */
+export function getConfigValue(path, defaultValue = undefined) {
+  const config = getConfig();
+  const parts = path.split(".");
+  let value = config;
+
+  for (const part of parts) {
+    if (value && typeof value === "object" && part in value) {
+      value = value[part];
+    } else {
+      return defaultValue;
+    }
+  }
+
+  return value;
+}

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -1,0 +1,403 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  loadConfig,
+  getConfig,
+  resetConfig,
+  getConfigValue,
+  defaultConfig,
+} from "../src/core/config.js";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+describe("Configuration Module", () => {
+  let tempDir;
+  let originalEnv;
+
+  beforeEach(async () => {
+    // Save original environment
+    originalEnv = { ...process.env };
+
+    // Create temp directory for test config files
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "config-test-"));
+
+    // Reset config before each test
+    resetConfig();
+  });
+
+  afterEach(async () => {
+    // Restore original environment
+    process.env = originalEnv;
+
+    // Clean up temp directory
+    if (tempDir) {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+
+    // Reset config after each test
+    resetConfig();
+  });
+
+  describe("defaultConfig", () => {
+    it("should have all required configuration sections", () => {
+      expect(defaultConfig).toHaveProperty("orchestrator");
+      expect(defaultConfig).toHaveProperty("taskRunner");
+      expect(defaultConfig).toHaveProperty("llm");
+      expect(defaultConfig).toHaveProperty("ui");
+      expect(defaultConfig).toHaveProperty("paths");
+      expect(defaultConfig).toHaveProperty("validation");
+      expect(defaultConfig).toHaveProperty("logging");
+    });
+
+    it("should have sensible default values", () => {
+      expect(defaultConfig.orchestrator.shutdownTimeout).toBe(2000);
+      expect(defaultConfig.taskRunner.maxRefinementAttempts).toBe(2);
+      expect(defaultConfig.llm.defaultProvider).toBe("openai");
+      expect(defaultConfig.ui.port).toBe(3000);
+      expect(defaultConfig.logging.level).toBe("info");
+    });
+  });
+
+  describe("getConfig", () => {
+    it("should return default config on first call", () => {
+      const config = getConfig();
+      expect(config.orchestrator.shutdownTimeout).toBe(2000);
+      expect(config.llm.defaultProvider).toBe("openai");
+    });
+
+    it("should return cached config on subsequent calls", () => {
+      const config1 = getConfig();
+      const config2 = getConfig();
+      expect(config1).toBe(config2);
+    });
+
+    it("should load environment variables", () => {
+      process.env.PO_SHUTDOWN_TIMEOUT = "5000";
+      process.env.PO_DEFAULT_PROVIDER = "deepseek";
+      resetConfig();
+
+      const config = getConfig();
+      expect(config.orchestrator.shutdownTimeout).toBe(5000);
+      expect(config.llm.defaultProvider).toBe("deepseek");
+    });
+  });
+
+  describe("loadConfig", () => {
+    it("should load config from file", async () => {
+      const configPath = path.join(tempDir, "test-config.json");
+      const testConfig = {
+        orchestrator: {
+          shutdownTimeout: 3000,
+        },
+        llm: {
+          defaultProvider: "anthropic",
+        },
+      };
+
+      await fs.writeFile(configPath, JSON.stringify(testConfig));
+
+      const config = await loadConfig({ configPath });
+      expect(config.orchestrator.shutdownTimeout).toBe(3000);
+      expect(config.llm.defaultProvider).toBe("anthropic");
+    });
+
+    it("should merge file config with defaults", async () => {
+      const configPath = path.join(tempDir, "test-config.json");
+      const testConfig = {
+        orchestrator: {
+          shutdownTimeout: 3000,
+        },
+      };
+
+      await fs.writeFile(configPath, JSON.stringify(testConfig));
+
+      const config = await loadConfig({ configPath });
+      expect(config.orchestrator.shutdownTimeout).toBe(3000);
+      expect(config.orchestrator.processSpawnRetries).toBe(3); // default value
+      expect(config.llm.defaultProvider).toBe("openai"); // default value
+    });
+
+    it("should prioritize environment variables over file config", async () => {
+      const configPath = path.join(tempDir, "test-config.json");
+      const testConfig = {
+        orchestrator: {
+          shutdownTimeout: 3000,
+        },
+      };
+
+      await fs.writeFile(configPath, JSON.stringify(testConfig));
+      process.env.PO_SHUTDOWN_TIMEOUT = "5000";
+
+      const config = await loadConfig({ configPath });
+      expect(config.orchestrator.shutdownTimeout).toBe(5000);
+    });
+
+    it("should handle missing config file gracefully", async () => {
+      const configPath = path.join(tempDir, "nonexistent.json");
+      const config = await loadConfig({ configPath });
+      expect(config.orchestrator.shutdownTimeout).toBe(2000); // default
+    });
+
+    it("should validate config by default", async () => {
+      const configPath = path.join(tempDir, "invalid-config.json");
+      const invalidConfig = {
+        orchestrator: {
+          shutdownTimeout: -1000, // invalid: must be positive
+        },
+      };
+
+      await fs.writeFile(configPath, JSON.stringify(invalidConfig));
+
+      await expect(loadConfig({ configPath })).rejects.toThrow(
+        "Configuration validation failed"
+      );
+    });
+
+    it("should skip validation when requested", async () => {
+      const configPath = path.join(tempDir, "invalid-config.json");
+      const invalidConfig = {
+        orchestrator: {
+          shutdownTimeout: -1000,
+        },
+      };
+
+      await fs.writeFile(configPath, JSON.stringify(invalidConfig));
+
+      const config = await loadConfig({ configPath, validate: false });
+      expect(config.orchestrator.shutdownTimeout).toBe(-1000);
+    });
+  });
+
+  describe("Environment Variable Loading", () => {
+    it("should load all orchestrator settings from env", () => {
+      process.env.PO_SHUTDOWN_TIMEOUT = "3000";
+      process.env.PO_PROCESS_SPAWN_RETRIES = "5";
+      process.env.PO_LOCK_FILE_TIMEOUT = "10000";
+      process.env.PO_WATCH_DEBOUNCE = "200";
+      resetConfig();
+
+      const config = getConfig();
+      expect(config.orchestrator.shutdownTimeout).toBe(3000);
+      expect(config.orchestrator.processSpawnRetries).toBe(5);
+      expect(config.orchestrator.lockFileTimeout).toBe(10000);
+      expect(config.orchestrator.watchDebounce).toBe(200);
+    });
+
+    it("should load all task runner settings from env", () => {
+      process.env.PO_MAX_REFINEMENT_ATTEMPTS = "5";
+      process.env.PO_STAGE_TIMEOUT = "600000";
+      process.env.PO_LLM_REQUEST_TIMEOUT = "120000";
+      resetConfig();
+
+      const config = getConfig();
+      expect(config.taskRunner.maxRefinementAttempts).toBe(5);
+      expect(config.taskRunner.stageTimeout).toBe(600000);
+      expect(config.taskRunner.llmRequestTimeout).toBe(120000);
+    });
+
+    it("should load all LLM settings from env", () => {
+      process.env.PO_DEFAULT_PROVIDER = "anthropic";
+      process.env.PO_DEFAULT_MODEL = "claude-3-opus";
+      process.env.PO_MAX_CONCURRENCY = "10";
+      resetConfig();
+
+      const config = getConfig();
+      expect(config.llm.defaultProvider).toBe("anthropic");
+      expect(config.llm.defaultModel).toBe("claude-3-opus");
+      expect(config.llm.maxConcurrency).toBe(10);
+    });
+
+    it("should load UI settings from env", () => {
+      process.env.PORT = "4000";
+      process.env.PO_UI_HOST = "0.0.0.0";
+      process.env.PO_HEARTBEAT_INTERVAL = "60000";
+      resetConfig();
+
+      const config = getConfig();
+      expect(config.ui.port).toBe(4000);
+      expect(config.ui.host).toBe("0.0.0.0");
+      expect(config.ui.heartbeatInterval).toBe(60000);
+    });
+
+    it("should prefer PO_UI_PORT over PORT", () => {
+      process.env.PORT = "4000";
+      process.env.PO_UI_PORT = "5000";
+      resetConfig();
+
+      const config = getConfig();
+      expect(config.ui.port).toBe(5000);
+    });
+
+    it("should load path settings from env", () => {
+      process.env.PO_ROOT = "/custom/root";
+      process.env.PO_DATA_DIR = "custom-data";
+      process.env.PO_CONFIG_DIR = "custom-config";
+      resetConfig();
+
+      const config = getConfig();
+      expect(config.paths.root).toBe("/custom/root");
+      expect(config.paths.dataDir).toBe("custom-data");
+      expect(config.paths.configDir).toBe("custom-config");
+    });
+
+    it("should load logging settings from env", () => {
+      process.env.PO_LOG_LEVEL = "debug";
+      process.env.PO_LOG_FORMAT = "text";
+      process.env.PO_LOG_DESTINATION = "/var/log/pipeline.log";
+      resetConfig();
+
+      const config = getConfig();
+      expect(config.logging.level).toBe("debug");
+      expect(config.logging.format).toBe("text");
+      expect(config.logging.destination).toBe("/var/log/pipeline.log");
+    });
+  });
+
+  describe("Configuration Validation", () => {
+    it("should reject negative shutdown timeout", async () => {
+      const config = {
+        orchestrator: { shutdownTimeout: -100 },
+      };
+
+      await expect(
+        loadConfig({
+          configPath: await writeTestConfig(config),
+        })
+      ).rejects.toThrow("shutdownTimeout must be positive");
+    });
+
+    it("should reject negative process spawn retries", async () => {
+      const config = {
+        orchestrator: { processSpawnRetries: -1 },
+      };
+
+      await expect(
+        loadConfig({
+          configPath: await writeTestConfig(config),
+        })
+      ).rejects.toThrow("processSpawnRetries must be non-negative");
+    });
+
+    it("should reject negative max refinement attempts", async () => {
+      const config = {
+        taskRunner: { maxRefinementAttempts: -1 },
+      };
+
+      await expect(
+        loadConfig({
+          configPath: await writeTestConfig(config),
+        })
+      ).rejects.toThrow("maxRefinementAttempts must be non-negative");
+    });
+
+    it("should reject invalid port numbers", async () => {
+      const config = {
+        ui: { port: 70000 },
+      };
+
+      await expect(
+        loadConfig({
+          configPath: await writeTestConfig(config),
+        })
+      ).rejects.toThrow("port must be between 1 and 65535");
+    });
+
+    it("should reject invalid provider", async () => {
+      const config = {
+        llm: { defaultProvider: "invalid-provider" },
+      };
+
+      await expect(
+        loadConfig({
+          configPath: await writeTestConfig(config),
+        })
+      ).rejects.toThrow("defaultProvider must be one of");
+    });
+
+    it("should reject invalid log level", async () => {
+      const config = {
+        logging: { level: "invalid" },
+      };
+
+      await expect(
+        loadConfig({
+          configPath: await writeTestConfig(config),
+        })
+      ).rejects.toThrow("level must be one of");
+    });
+
+    it("should accept valid configuration", async () => {
+      const config = {
+        orchestrator: { shutdownTimeout: 5000 },
+        taskRunner: { maxRefinementAttempts: 3 },
+        llm: { defaultProvider: "deepseek", maxConcurrency: 10 },
+        ui: { port: 8080 },
+        logging: { level: "debug" },
+      };
+
+      const loaded = await loadConfig({
+        configPath: await writeTestConfig(config),
+      });
+
+      expect(loaded.orchestrator.shutdownTimeout).toBe(5000);
+      expect(loaded.taskRunner.maxRefinementAttempts).toBe(3);
+      expect(loaded.llm.defaultProvider).toBe("deepseek");
+      expect(loaded.ui.port).toBe(8080);
+      expect(loaded.logging.level).toBe("debug");
+    });
+  });
+
+  describe("getConfigValue", () => {
+    it("should get nested config value by path", () => {
+      const value = getConfigValue("orchestrator.shutdownTimeout");
+      expect(value).toBe(2000);
+    });
+
+    it("should get top-level config value", () => {
+      const value = getConfigValue("orchestrator");
+      expect(value).toHaveProperty("shutdownTimeout");
+    });
+
+    it("should return default value for missing path", () => {
+      const value = getConfigValue("nonexistent.path", "default");
+      expect(value).toBe("default");
+    });
+
+    it("should return undefined for missing path without default", () => {
+      const value = getConfigValue("nonexistent.path");
+      expect(value).toBeUndefined();
+    });
+
+    it("should handle deep nesting", () => {
+      const value = getConfigValue("orchestrator.shutdownTimeout");
+      expect(value).toBe(2000);
+    });
+  });
+
+  describe("resetConfig", () => {
+    it("should clear cached config", () => {
+      const config1 = getConfig();
+      resetConfig();
+      const config2 = getConfig();
+      expect(config1).not.toBe(config2);
+    });
+
+    it("should reload config with new environment variables", () => {
+      const config1 = getConfig();
+      expect(config1.orchestrator.shutdownTimeout).toBe(2000);
+
+      process.env.PO_SHUTDOWN_TIMEOUT = "5000";
+      resetConfig();
+
+      const config2 = getConfig();
+      expect(config2.orchestrator.shutdownTimeout).toBe(5000);
+    });
+  });
+
+  // Helper function to write test config
+  async function writeTestConfig(config) {
+    const configPath = path.join(tempDir, `config-${Date.now()}.json`);
+    await fs.writeFile(configPath, JSON.stringify(config));
+    return configPath;
+  }
+});

--- a/tests/llm.test.js
+++ b/tests/llm.test.js
@@ -611,9 +611,9 @@ describe("LLM Module", () => {
       const mockFn = vi.fn().mockRejectedValue(authError);
 
       // Act & Assert
-      await expect(withRetry(mockFn, [], 3, 10)).rejects.toThrow(
-        "API key invalid"
-      );
+      await expect(
+        withRetry(mockFn, [], { maxRetries: 3, backoffMs: 10 })
+      ).rejects.toThrow("API key invalid");
       expect(mockFn).toHaveBeenCalledTimes(1);
     });
 
@@ -628,7 +628,7 @@ describe("LLM Module", () => {
         .mockResolvedValue("success");
 
       // Act
-      const promise = withRetry(mockFn, [], 3, 100);
+      const promise = withRetry(mockFn, [], { maxRetries: 3, backoffMs: 100 });
 
       // Advance timers for first retry (100ms)
       await vi.advanceTimersByTimeAsync(100);


### PR DESCRIPTION
# Why

The system currently has hardcoded configuration values scattered throughout the codebase (timeouts, retry counts, port numbers, etc.), making it difficult to:

- Adjust behavior without code changes
- Test different configurations
- Deploy with environment-specific settings
- Understand what values can be configured

This PR implements Phase 1.2 from architecture-fix.md to centralize all configuration into a single, testable module with support for environment variables, config files, and validation.

# What Changed

- **Created `src/core/config.js`**: Comprehensive configuration management module with:

  - Three-tier priority system: environment variables > config file > defaults
  - Deep merge support for partial config files
  - Validation with clear error messages
  - Lazy loading with caching for performance
  - Helper functions for accessing nested values
  - Reset capability for testing

- **Added `config.schema.json`**: JSON schema defining all configuration options and their constraints

- **Added `config.example.json`**: Template file showing all available configuration options

- **Updated core modules** to use centralized config:

  - `orchestrator.js`: Watch settings and shutdown timeout
  - `task-runner.js`: Max refinement attempts
  - `validation.js`: Seed validation rules
  - `llm/index.js`: Retry settings

- **Added comprehensive test suite**: 32 tests covering all configuration scenarios including:
  - Default values
  - Environment variable loading
  - Config file loading and merging
  - Validation
  - Helper functions

## Configuration Options Now Available

- **Orchestrator**: `shutdownTimeout`, `processSpawnRetries`, `lockFileTimeout`, `watchDebounce`, `watchStabilityThreshold`, `watchPollInterval`
- **Task Runner**: `maxRefinementAttempts`, `stageTimeout`, `llmRequestTimeout`
- **LLM**: `defaultProvider`, `defaultModel`, `maxConcurrency`, `retryMaxAttempts`, `retryBackoffMs`
- **UI**: `port`, `host`, `heartbeatInterval`, `maxRecentChanges`
- **Validation**: `seedNameMinLength`, `seedNameMaxLength`, `seedNamePattern`
- **Logging**: `level`, `format`, `destination`
- **Paths**: `root`, `dataDir`, `configDir`, `pendingDir`, `currentDir`, `completeDir`

# How Was This Tested

- All 272 existing tests pass (8 skipped)
- Added 32 new configuration-specific tests covering:
  - Default configuration structure
  - Environment variable loading for all settings
  - Config file loading and merging
  - Priority ordering (env > file > defaults)
  - Validation of invalid values
  - Helper functions (getConfig, getConfigValue, resetConfig)
  - Edge cases and error handling

Manual verification:

- Tested with environment variables
- Tested with config file
- Verified validation catches invalid values
- Confirmed backward compatibility with existing code

# Screenshots / Demos

N/A - Backend configuration system

# Risks & Rollback

**Risks:**

- Minimal - all changes are additive and backward compatible
- Existing hardcoded values are preserved as defaults
- No breaking changes to public APIs

**Rollback plan:**

- Revert this single commit
- All hardcoded values will return to their previous inline locations
- No data migration needed

# Performance / Security / Accessibility

**Performance:**

- Lazy loading with caching ensures minimal overhead
- Config loaded once and cached for subsequent calls
- No performance impact on existing functionality

**Security:**

- Validation prevents invalid configuration values
- Environment variables follow standard security practices
- No sensitive data stored in config files (API keys remain in env vars)

**Accessibility:**

- N/A - Backend configuration system

# Linked Issues

Related to architecture improvements outlined in `docs/architecture-fix.md` Phase 1.2

# Checklist

- [x] Tests added/updated (32 new tests)
- [x] Docs updated (config.example.json, config.schema.json)
- [x] No breaking changes
- [x] CI green (all 272 tests passing)
