### PR TITLE
fix(demo): correct pipeline-runner path in integrated-demo

### DIFF
--- a/demo/integrated-demo.js
+++ b/demo/integrated-demo.js
@@ -87,10 +87,19 @@ class IntegratedDemo {
 
       const child = spawn(
         process.execPath,
-        ["./../lib/pipeline-runner.js", pipelineName],
+        ["../src/core/pipeline-runner.js", pipelineName],
         {
           stdio: ["ignore", "pipe", "pipe"],
-          env: process.env,
+          env: {
+            ...process.env,
+            PO_ROOT: ROOT,
+            PO_DATA_DIR: path.join(ROOT, "pipeline-data"),
+            PO_CURRENT_DIR: CURRENT_DIR,
+            PO_COMPLETE_DIR: COMPLETE_DIR,
+            PO_CONFIG_DIR: path.join(ROOT, "pipeline-config"),
+            PO_PIPELINE_PATH: path.join(ROOT, "pipeline-config/pipeline.json"),
+            PO_TASK_REGISTRY: path.join(ROOT, "pipeline-tasks/index.js"),
+          },
           cwd: ROOT,
         }
       );


### PR DESCRIPTION
# Why

The demo's `integrated-demo.js` was using an incorrect path to spawn the pipeline-runner process, preventing the demo from executing correctly. This addresses problem 3 from `docs/demo-refactor.md`.

# What Changed

- Fixed pipeline-runner path from `./../lib/pipeline-runner.js` to `../src/core/pipeline-runner.js`
- Added required environment variables to the spawn call:
  - `PO_ROOT`: Root directory for the demo
  - `PO_DATA_DIR`: Pipeline data directory
  - `PO_CURRENT_DIR`: Current pipeline working directory
  - `PO_COMPLETE_DIR`: Completed pipeline directory
  - `PO_CONFIG_DIR`: Pipeline configuration directory
  - `PO_PIPELINE_PATH`: Path to pipeline.json
  - `PO_TASK_REGISTRY`: Path to task registry

# How Was This Tested

- Verified the path change aligns with the actual location of `pipeline-runner.js` in `src/core/`
- Confirmed environment variables match those expected by the pipeline-runner
- Code review against architecture documentation in `docs/demo-refactor.md`

# Screenshots / Demos

N/A - This is a path correction fix

# Risks & Rollback

**Risks**: Minimal - this is a straightforward path correction

**Rollback plan**: Revert commit 6109cad to restore previous (broken) path

# Performance / Security / Accessibility

- No performance impact
- No security concerns - environment variables are properly scoped
- No accessibility impact

# Linked Issues

Related to #22

# Checklist

- [x] Path corrected to match actual file location
- [x] Environment variables added for proper pipeline execution
- [x] No breaking changes
- [x] Follows conventional commit format
