### PR TITLE
fix(demo): correct filename in setup verification

### DIFF
--- a/demo/setup-demo.js
+++ b/demo/setup-demo.js
@@ -173,7 +173,7 @@ async function verifySetup() {
     "pipeline.json",
     "pipeline-config/tasks/index.js",
     "pipeline-pending/renewable-energy-seed.json",
-    "integrated-demo-runner.js",
+    "integrated-demo.js",
     "mock-chatgpt.js",
   ];
 


### PR DESCRIPTION
# Why

The demo setup script was failing with "Missing required files: integrated-demo-runner.js" error. This prevented users from running `npm run setup` successfully in the demo directory.

The issue was caused by a mismatch between the filename being checked in the verification step and the actual filename of the demo runner.

# What Changed

- Updated `demo/setup-demo.js` verification to check for `integrated-demo.js` instead of `integrated-demo-runner.js`
- The actual demo runner file is named `integrated-demo.js`, not `integrated-demo-runner.js`

# How Was This Tested

- Ran `cd demo && npm run setup` successfully
- Verified all setup steps complete without errors
- Confirmed all required files are properly detected:
  - ✓ pipeline.json
  - ✓ pipeline-config/tasks/index.js
  - ✓ pipeline-pending/renewable-energy-seed.json
  - ✓ integrated-demo.js
  - ✓ mock-chatgpt.js
  - ✓ Node.js v22.9.0

# Screenshots / Demos

N/A - CLI fix only

# Risks & Rollback

**Risks**: None - this is a simple filename correction in a verification check

**Rollback plan**: Revert the commit to restore the old (incorrect) filename check

# Performance / Security / Accessibility

No impact - this only affects the setup verification step

# Linked Issues

Fixes setup failure reported in task

# Checklist

- [x] Tests added/updated - N/A (setup script fix)
- [x] Docs updated - N/A (no doc changes needed)
- [x] No breaking changes
- [x] CI green - will verify after push
