### PR TITLE
build(deps): configure package for npm publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,21 @@
 {
-  "name": "prompt-orchestration-pipeline",
+  "name": "@ryanfw/prompt-orchestration-pipeline",
   "version": "0.0.1",
   "description": "A Prompt-orchestration pipeline (POP) is a framework for building, running, and experimenting with complex chains of LLM tasks.",
   "type": "module",
-  "main": "index.js",
+  "main": "src/ui/server.js",
+  "files": [
+    "src",
+    "README.md",
+    "LICENSE"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ryan-mahoney/prompt-orchestration-pipeline.git"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "test": "vitest run",
     "ui": "nodemon src/ui/server.js",


### PR DESCRIPTION
# Why

Prepare the package for distribution via npm registry. The package needs proper configuration to be published as a scoped package with appropriate metadata and access controls.

# What Changed

- Changed package name from `prompt-orchestration-pipeline` to `@ryanfw/prompt-orchestration-pipeline` (scoped package)
- Updated main entry point from `index.js` to `src/ui/server.js`
- Added `files` array to specify published content: `src`, `README.md`, `LICENSE`
- Added repository information pointing to GitHub repository
- Added `publishConfig` with `access: "public"` for scoped package publishing

# How Was This Tested

- Manual verification of package.json structure
- No functional changes to code, only package metadata

# Screenshots / Demos (if UI)

N/A - Configuration change only

# Risks & Rollback

- **Known risks**: Minimal risk as this only affects package publishing configuration, not runtime behavior
- **Rollback plan**: Revert commit e5503e4 to restore previous package.json configuration

# Performance / Security / Accessibility

- **Security**: Scoped package name provides better namespace control
- **Performance**: No impact
- **Accessibility**: N/A

# Linked Issues

N/A

# Checklist

- [x] Tests added/updated (N/A - configuration only)
- [x] Docs updated (N/A - no user-facing changes)
- [x] No breaking changes
- [x] CI green (pending)
