### PR TITLE
docs: add plan to remove upload gate

### DIFF
--- a/docs/plan-remove-upload-gate.md
+++ b/docs/plan-remove-upload-gate.md
@@ -1,0 +1,132 @@
+Got it—here’s the tightened plan with upload **never** disabled and steps 9–11 removed.
+
+# Step-by-Step Plan (Revised)
+
+## Acceptance Checklist
+
+- Upload control is **always enabled** (clean project, SSE disconnected, API error present—doesn’t matter).
+- “Upload disabled” text or any visual/ARIA disabled state is **gone**.
+- Failed attempts surface inline errors via existing `normalizeUploadError`.
+- No server endpoint changes; E2E upload path remains functional.
+- SSE behavior (not opening on empty data) remains unchanged.
+
+---
+
+## 1) Prepare & Locate
+
+- Open `src/pages/PromptPipelineDashboard.jsx`.
+- Find:
+  - The call to the jobs list hook (e.g., `useJobListWithUpdates`).
+  - Any derived `connectionState` or similar.
+  - The `<UploadSeed ... />` usage (look for `disabled` prop).
+
+**Completion check:** You can point to every place where upload is gated or the `disabled` prop is passed.
+
+---
+
+## 2) Remove Gating in Dashboard
+
+- **Delete** any computed variable used to gate upload (e.g., `uploadDisabled`, `connectionState` checks for `<UploadSeed>`).
+- **Remove** the `disabled={...}` prop from `<UploadSeed>` entirely.
+- Keep `connectionState` if other UI uses it (badges, banners, etc.), but it must not affect upload.
+
+**Completion check:** `<UploadSeed>` has **no** `disabled` prop and no conditional upload gating in the dashboard.
+
+---
+
+## 3) Simplify UploadSeed Props
+
+- Open the `UploadSeed` component file (e.g., `src/components/UploadSeed.jsx`; adjust path to your repo).
+- Remove the `disabled` prop from its prop list/TypeScript types (if present).
+- Delete any conditional rendering branches that rely on `disabled` to show “Upload disabled” or to block UI.
+
+**Completion check:** The component’s interface no longer accepts or reads a `disabled` prop.
+
+---
+
+## 4) Remove Internal Disabled Logic in UploadSeed
+
+- Ensure:
+  - No `disabled` attributes are set on inputs/buttons.
+  - No `aria-disabled` or styles implying disabled state remain.
+  - Any dropzone library usage (e.g., `useDropzone`) is not passed a `disabled` flag.
+  - “Upload disabled” copy is removed.
+
+**Completion check:** All interaction paths (click-to-select, drag-and-drop, keyboard) are available at all times.
+
+---
+
+## 5) Keep Inline Error Handling
+
+- Confirm `normalizeUploadError` is still used on failed POSTs (network errors, validation failures).
+- Make sure error messages render inline within the upload area and do not block subsequent attempts.
+
+**Completion check:** A failed attempt shows a clear inline error; user can immediately retry.
+
+---
+
+## 6) Update Automated Tests
+
+- In `tests/PromptPipelineDashboard.test.jsx`, update/replace assertions:
+  - **New Test A:** “upload is enabled when SSE is disconnected and data is empty”
+    - Mock `connectionStatus = "disconnected"`, `isConnected = false`, `error = null`.
+    - Assert upload control is interactive (no `disabled` attribute, actionable button/input present).
+
+  - **New Test B:** “upload is enabled even when jobs API returns an error”
+    - Mock `error` as truthy.
+    - Assert upload control remains interactive (never disabled).
+
+  - **Remove/modify** any test expecting the upload to be disabled under any condition.
+
+- If you have `tests/UploadSeed.test.jsx`, remove cases tied to `disabled` prop and add checks that the control is always actionable.
+
+**Completion check:** No test refers to a disabled state for upload; new tests confirm it’s always enabled.
+
+---
+
+## 7) UI Copy & Accessibility Audit
+
+- Scan for any copy implying upload requires “connected” or “SSE active” status; update to neutral phrasing (e.g., “Disconnected from live updates; uploads still available.”) if needed.
+- Verify accessible names/roles:
+  - Primary upload trigger has a clear label.
+  - Keyboard users can focus and activate all upload controls.
+  - Errors announced where applicable (if you already use ARIA live regions, ensure they still fire).
+
+**Completion check:** Messaging is accurate, and accessibility is not degraded.
+
+---
+
+## 8) Manual QA Scenarios
+
+- **Clean project (no jobs, SSE closed):** Upload is available; selecting a valid file initiates upload.
+- **Disconnected but API healthy:** Upload remains available; successful upload proceeds; jobs list populates; SSE can connect later.
+- **Jobs API error present:** Upload is still available; attempting upload may succeed (endpoint independent) or fail; failures render inline and allow retry.
+- **Server down during upload:** Inline error appears via `normalizeUploadError`; control remains interactive for retry.
+
+**Completion check:** In all scenarios, the control is never disabled and errors are handled inline.
+
+---
+
+## File Change List (path → purpose)
+
+- `src/pages/PromptPipelineDashboard.jsx` → Remove all upload gating; remove `disabled` prop from `<UploadSeed>`.
+- `src/components/UploadSeed.jsx` (adjust path) → Remove `disabled` prop support, disabled attributes/ARIA, and “Upload disabled” copy.
+- `tests/PromptPipelineDashboard.test.jsx` → Replace disabled-state tests with “always enabled” tests.
+- `tests/UploadSeed.test.jsx` (if present) → Remove disabled-prop tests; ensure interactivity tests pass.
+
+---
+
+## Risks & Mitigations
+
+- **Risk:** Users attempt upload while backend is down.
+  **Mitigation:** Inline error handling (already present) communicates failure and allows immediate retry.
+- **Risk:** Legacy code assumes `disabled` exists on `UploadSeed`.
+  **Mitigation:** Search repo for `UploadSeed` usages and remove any `disabled` props; tests will catch stragglers.
+
+---
+
+## Non-Goals
+
+- No changes to `/api/upload/seed`.
+- No changes to SSE opening behavior in the jobs list hook.
+- No changes to unrelated UI elements besides removing misleading “disabled” messaging.

--- a/src/components/UploadSeed.jsx
+++ b/src/components/UploadSeed.jsx
@@ -20,10 +20,9 @@ export const normalizeUploadError = (err) => {
  * UploadSeed component for uploading seed files
  *
  * @param {Object} props
- * @param {boolean} props.disabled - Whether the upload area is disabled
  * @param {function} props.onUploadSuccess - Callback called on successful upload with { jobName }
  */
-export default function UploadSeed({ disabled = false, onUploadSuccess }) {
+export default function UploadSeed({ onUploadSuccess }) {
   const fileInputRef = React.useRef(null);
   const [showSample, setShowSample] = useState(false);
   const [error, setError] = useState(null);
@@ -83,16 +82,14 @@ export default function UploadSeed({ disabled = false, onUploadSuccess }) {
   };
 
   const handleDropAreaClick = () => {
-    if (!disabled && fileInputRef.current) {
+    if (fileInputRef.current) {
       fileInputRef.current.click();
     }
   };
 
   const handleDragOver = (event) => {
     event.preventDefault();
-    if (!disabled) {
-      event.currentTarget.classList.add("border-blue-500", "bg-blue-50");
-    }
+    event.currentTarget.classList.add("border-blue-500", "bg-blue-50");
   };
 
   const handleDragLeave = (event) => {
@@ -104,11 +101,10 @@ export default function UploadSeed({ disabled = false, onUploadSuccess }) {
     event.preventDefault();
     event.currentTarget.classList.remove("border-blue-500", "bg-blue-50");
 
-    if (!disabled && event.dataTransfer.files.length > 0) {
+    if (event.dataTransfer.files.length > 0) {
       const files = event.dataTransfer.files;
       const fileInput = fileInputRef.current;
       if (fileInput) {
-        // Create a new FileList-like object
         const dataTransfer = new DataTransfer();
         dataTransfer.items.add(files[0]);
         fileInput.files = dataTransfer.files;
@@ -142,19 +138,14 @@ export default function UploadSeed({ disabled = false, onUploadSuccess }) {
         data-testid="upload-area"
         className={`
           border-2 border-dashed rounded-lg p-6 text-center cursor-pointer transition-colors
-          ${
-            disabled
-              ? "border-gray-300 bg-gray-100 text-gray-400 cursor-not-allowed"
-              : "border-gray-400 bg-white text-gray-600 hover:border-blue-500 hover:bg-blue-50"
-          }
+          border-gray-400 bg-white text-gray-600 hover:border-blue-500 hover:bg-blue-50
         `}
         onClick={handleDropAreaClick}
         onDragOver={handleDragOver}
         onDragLeave={handleDragLeave}
         onDrop={handleDrop}
         role="button"
-        tabIndex={disabled ? -1 : 0}
-        aria-disabled={disabled}
+        tabIndex={0}
       >
         <div className="space-y-2">
           <svg
@@ -172,9 +163,7 @@ export default function UploadSeed({ disabled = false, onUploadSuccess }) {
             />
           </svg>
           <div className="text-sm">
-            <span className="font-medium text-gray-900">
-              {disabled ? "Upload disabled" : "Click to upload"}
-            </span>{" "}
+            <span className="font-medium text-gray-900">Click to upload</span>{" "}
             or drag and drop
           </div>
           <p className="text-xs text-gray-500">JSON files only</p>
@@ -187,7 +176,6 @@ export default function UploadSeed({ disabled = false, onUploadSuccess }) {
         accept=".json"
         className="hidden"
         onChange={handleFileChange}
-        disabled={disabled}
         data-testid="file-input"
       />
 

--- a/src/pages/PromptPipelineDashboard.jsx
+++ b/src/pages/PromptPipelineDashboard.jsx
@@ -218,10 +218,7 @@ export default function PromptPipelineDashboard({ isConnected }) {
                   </Box>
                 )}
 
-                <UploadSeed
-                  disabled={!connectionState}
-                  onUploadSuccess={handleSeedUploadSuccess}
-                />
+                <UploadSeed onUploadSuccess={handleSeedUploadSuccess} />
               </Flex>
             </Card>
           )}

--- a/tests/PromptPipelineDashboard.test.jsx
+++ b/tests/PromptPipelineDashboard.test.jsx
@@ -123,7 +123,7 @@ describe("PromptPipelineDashboard (integration-ish)", () => {
     expect(buttons.some((b) => b && b.disabled === false)).toBe(true);
   });
 
-  it("disables upload when the jobs API reports an error", async () => {
+  it("keeps upload enabled even when the jobs API reports an error", async () => {
     useJobListWithUpdates.mockReturnValue({
       loading: false,
       data: [],
@@ -134,9 +134,8 @@ describe("PromptPipelineDashboard (integration-ish)", () => {
 
     render(<PromptPipelineDashboard />);
 
-    // There may be multiple mount instances during StrictMode double-render;
-    // assert at least one rendered UploadSeed button is disabled when API errors.
+    // Upload should remain enabled even when API reports an error.
     const buttons = screen.getAllByTestId("upload-seed-button");
-    expect(buttons.some((b) => b && b.disabled === true)).toBe(true);
+    expect(buttons.some((b) => b && b.disabled === false)).toBe(true);
   });
 });


### PR DESCRIPTION
docs: add plan to remove upload gate

- Add plan document describing removal of the upload gate from the demo flow.
- Update UploadSeed and PromptPipelineDashboard to align with proposed flow changes.
- Adjust tests to reflect UI changes.

Why:
The upload gate complicates the demo flow and blocks streamlined seed uploads. This plan documents the rationale and the proposed steps to remove it.

Files changed:
- docs/plan-remove-upload-gate.md (new)
- src/components/UploadSeed.jsx (updated)
- src/pages/PromptPipelineDashboard.jsx (updated)
- tests/PromptPipelineDashboard.test.jsx (updated)

How tested:
- Unit/UI tests updated where required (see tests/PromptPipelineDashboard.test.jsx)
- Manual verification steps are documented in the plan file.
