### PR TITLE
feat(ui): show job status and id in PipelineDetail header; remove JobDetail header

### DIFF
--- a/src/components/JobDetail.jsx
+++ b/src/components/JobDetail.jsx
@@ -212,31 +212,6 @@ required:
 
   return (
     <div className="flex h-full flex-col">
-      <header className="sticky top-0 z-10 bg-white border-b border-gray-200 px-6 py-4 mb-6">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={onClose}
-              aria-label="Back to jobs"
-              className="text-gray-600 hover:text-gray-900"
-            >
-              <ChevronLeft className="h-4 w-4" /> Back
-            </Button>
-            <div>
-              <h1 className="text-2xl font-semibold text-gray-900">
-                {job.name}
-              </h1>
-              <p className="text-sm text-gray-600 mt-1">ID: {job.pipelineId}</p>
-            </div>
-          </div>
-          <div className="flex items-center gap-2">
-            {statusBadge(job.status)}
-          </div>
-        </div>
-      </header>
-
       <DAGGrid
         items={dagItems}
         activeIndex={activeIndex}

--- a/src/pages/PipelineDetail.jsx
+++ b/src/pages/PipelineDetail.jsx
@@ -4,6 +4,7 @@ import { Box, Flex, Text } from "@radix-ui/themes";
 import JobDetail from "../components/JobDetail.jsx";
 import { useJobDetailWithUpdates } from "../ui/client/hooks/useJobDetailWithUpdates.js";
 import Layout from "../components/Layout.jsx";
+import { statusBadge } from "../utils/ui.jsx";
 
 export default function PipelineDetail() {
   const { jobId } = useParams();
@@ -88,8 +89,22 @@ export default function PipelineDetail() {
       return { tasks: pipelineTasks };
     })();
 
+  // Header actions: job ID and status badge
+  const headerActions = (
+    <Flex align="center" gap="3" className="shrink-0">
+      <Text size="2" color="gray">
+        ID: {job.pipelineId || job.id || jobId}
+      </Text>
+      {statusBadge(job.status)}
+    </Flex>
+  );
+
   return (
-    <Layout title={job.name || "Pipeline Details"} showBackButton={true}>
+    <Layout
+      title={job.name || "Pipeline Details"}
+      showBackButton={true}
+      actions={headerActions}
+    >
       <JobDetail job={job} pipeline={pipeline} />
     </Layout>
   );

--- a/tests/JobDetail.array-tasks.test.jsx
+++ b/tests/JobDetail.array-tasks.test.jsx
@@ -71,8 +71,9 @@ describe("JobDetail - Array Tasks Support", () => {
       />
     );
 
-    // Check that the component rendered
-    expect(screen.getByText("Test Job")).toBeDefined();
+    // Check that the component rendered (job name is now in Layout header, not JobDetail)
+    // Verify DAG computation works
+    expect(computeDagItemsSpy).toHaveBeenCalledWith(job, pipeline);
 
     // Verify computeDagItems was called with the job
     expect(computeDagItemsSpy).toHaveBeenCalledWith(job, pipeline);

--- a/tests/JobDetail.detail-shaped.test.jsx
+++ b/tests/JobDetail.detail-shaped.test.jsx
@@ -98,9 +98,12 @@ describe("JobDetail - Detail-Shaped Job with Pipeline from API", () => {
       />
     );
 
-    // Check that the component rendered with correct job info
-    expect(screen.getByText("Test Pipeline Job")).toBeDefined();
-    expect(screen.getByText("ID: test-job-123")).toBeDefined();
+    // Check that the component rendered (job name and ID are now in Layout header, not JobDetail)
+    // Verify DAG computation still works
+    expect(computeDagItemsSpy).toHaveBeenCalledWith(
+      detailShapedJob,
+      detailShapedJob.pipeline
+    );
 
     // Verify computeDagItems was called with the detail-shaped job and pipeline
     expect(computeDagItemsSpy).toHaveBeenCalledWith(
@@ -171,8 +174,8 @@ describe("JobDetail - Detail-Shaped Job with Pipeline from API", () => {
       />
     );
 
-    // The component should render successfully without errors
-    expect(screen.getByText("Defensive Normalization Test")).toBeDefined();
+    // The component should render successfully without errors (job name is now in Layout header)
+    // Verify DAG computation works with the normalized data
 
     // DAG computation should work with the normalized data
     expect(computeDagItemsSpy).toHaveBeenCalled();
@@ -201,8 +204,9 @@ describe("JobDetail - Detail-Shaped Job with Pipeline from API", () => {
       />
     );
 
-    // Should still render successfully
-    expect(screen.getByText("Job Without Pipeline")).toBeDefined();
+    // Should still render successfully (job name is now in Layout header, not JobDetail)
+    // Verify DAG computation works
+    expect(computeDagItemsSpy).toHaveBeenCalled();
 
     // Should derive pipeline from job tasks
     expect(computeDagItemsSpy).toHaveBeenCalledWith(
@@ -245,8 +249,9 @@ describe("JobDetail - Detail-Shaped Job with Pipeline from API", () => {
       />
     );
 
-    // Should render successfully with all metadata preserved
-    expect(screen.getByText("Metadata Test Job")).toBeDefined();
+    // Should render successfully with all metadata preserved (job name is now in Layout header)
+    // Verify DAG computation works
+    expect(computeDagItemsSpy).toHaveBeenCalled();
 
     // DAG computation should have access to all task metadata
     expect(computeDagItemsSpy).toHaveBeenCalledWith(
@@ -292,7 +297,7 @@ describe("JobDetail - Detail-Shaped Job with Pipeline from API", () => {
     );
 
     // Should handle edge cases gracefully without crashing
-    expect(screen.getByText("Edge Cases Test Job")).toBeDefined();
+    // Job name is now in Layout header, not JobDetail component
     expect(computeDagItemsSpy).toHaveBeenCalled();
   });
 
@@ -356,8 +361,8 @@ describe("JobDetail - Detail-Shaped Job with Pipeline from API", () => {
       />
     );
 
-    // Verify the component rendered
-    expect(screen.getByText("Test Job with Error")).toBeDefined();
+    // Verify the component rendered (job name is now in Layout header, not JobDetail)
+    // DAG computation should work with error data
 
     // Get the DAG items from the mocked DAGGrid component (use the last one since multiple tests may have rendered)
     const dagItemsElements = screen.getAllByTestId("dag-items");

--- a/tests/PipelineDetail.test.jsx
+++ b/tests/PipelineDetail.test.jsx
@@ -306,4 +306,41 @@ describe("PipelineDetail", () => {
     // Hook should be called for valid IDs
     expect(useJobDetailWithUpdates).toHaveBeenCalledWith("validjobid123");
   });
+
+  it("renders status badge and job ID in header when data is loaded", () => {
+    const mockJob = {
+      id: "testjob123",
+      pipelineId: "testjob123",
+      name: "Test Running Job",
+      status: "running",
+      tasks: [
+        { name: "research", status: "pending" },
+        { name: "analysis", status: "pending" },
+      ],
+      pipeline: {
+        tasks: ["research", "analysis"],
+      },
+    };
+
+    // Mock the hook to return data with running status
+    vi.mocked(useJobDetailWithUpdates).mockReturnValue({
+      data: mockJob,
+      loading: false,
+      error: null,
+    });
+
+    __setParams({ jobId: "testjob123" });
+
+    render(
+      <MemoryRouter>
+        <PipelineDetail />
+      </MemoryRouter>
+    );
+
+    // Check for job ID in header
+    expect(screen.getByText(/ID: testjob123/i)).toBeDefined();
+
+    // Check for status badge content "Running"
+    expect(screen.getByText("Running")).toBeDefined();
+  });
 });


### PR DESCRIPTION
## Why
Consolidate visual information in the PipelineDetail view to reduce redundancy and improve the user experience by showing important pipeline metadata in the page header instead of duplicating it in the component.

## What Changed
- Move job status badge and pipeline ID into Layout header via PipelineDetail actions prop
- Remove redundant header section from JobDetail component to eliminate duplication
- Update tests to reflect header relocation and add assertions for new header content
- Maintain all existing DAG functionality and error handling

## Files Modified
- src/pages/PipelineDetail.jsx - inject actions with ID and status badge into Layout header
- src/components/JobDetail.jsx - remove header markup, keep only DAGGrid
- tests/PipelineDetail.test.jsx - add assertions for status badge and job ID in header
- tests/JobDetail.detail-shaped.test.jsx - remove header assertions (job name now in Layout)
- tests/JobDetail.error-alert.test.jsx - remove header assertion
- tests/JobDetail.array-tasks.test.jsx - remove header assertion

## How Was This Tested
- All 30 tests passing including new header assertions
- PipelineDetail now shows status badge and job ID in header
- JobDetail renders without redundant header
- Error handling and DAG functionality preserved
- Manual verification of header layout and status display

## Risks & Rollback
- Low risk: UI-only change with no API modifications
- Rollback: Restore header markup in JobDetail.jsx and remove actions from PipelineDetail.jsx
- No breaking changes to existing functionality

## Checklist
- [x] Tests added/updated
- [x] All tests passing (30/30)
- [x] No breaking changes
- [x] UI consistency maintained
- [x] Error handling preserved