### PR TITLE
fix(core): remove incorrect jobId from log path resolution

### DIFF
--- a/src/core/task-runner.js
+++ b/src/core/task-runner.js
@@ -146,7 +146,7 @@ function checkFlagTypeConflicts(currentFlags, newFlags, stageName) {
  * @returns {string} The full path to the logs directory
  */
 function ensureLogDirectory(workDir, jobId) {
-  const logsPath = path.join(workDir, jobId, "files", "logs");
+  const logsPath = path.join(workDir, "files", "logs");
   fs.mkdirSync(logsPath, { recursive: true });
   return logsPath;
 }
@@ -457,11 +457,16 @@ export async function runPipeline(modulePath, initialContext = {}) {
       // Add console output capture before stage execution
       const logPath = path.join(
         context.meta.workDir,
-        context.meta.jobId,
         "files",
         "logs",
         `stage-${stageName}.log`
       );
+      console.debug("[task-runner] stage log path resolution", {
+        stage: stageName,
+        workDir: context.meta.workDir,
+        jobId: context.meta.jobId,
+        logPath,
+      });
       const restoreConsole = captureConsoleOutput(logPath);
 
       // Set current stage before execution


### PR DESCRIPTION
# Why

Pipeline task execution was failing to create log files due to incorrect path resolution where jobId was being included twice in the path structure.

# What Changed

- Fix logs directory path in ensureLogDirectory() to exclude redundant jobId subdirectory  
- Fix stage log path construction to remove duplicate jobId from path
- Add debug logging for stage log path resolution to aid troubleshooting
- Ensures log files are written to correct workDir/files/logs/ location

# How Was This Tested

- Verified log files are now created in correct directory structure
- Confirmed debug logging provides useful path resolution information
- Tested pipeline execution to ensure log capture works properly

# Risks & Rollback

- Low risk: Only affects log file path resolution, not core pipeline logic
- Rollback: Revert to previous path construction if needed
- No breaking changes to API or pipeline behavior

# Performance / Security / Accessibility

- No performance impact
- No security implications
- No accessibility changes

# Checklist

- [x] Code follows project conventions
- [x] Changes are minimal and focused
- [x] Log file creation verified working
- [x] No breaking changes introduced