### PR TITLE
Add Alibaba env key, static model pricing table, and thinking docs

### DIFF
--- a/src/ui/pages/Code.tsx
+++ b/src/ui/pages/Code.tsx
@@ -163,7 +163,7 @@ const LLM_ARGS_CODE = `{
   seed?: number,               // For reproducibility
   provider?: string,           // Override default provider
   model?: string,              // Override default model
-  maxRetries?: number          // Auto-retry on failure
+  maxRetries?: number,         // Auto-retry on failure
   thinking?: "enabled"|"disabled", // Moonshot & Alibaba only (default: "enabled")
 }`;
 


### PR DESCRIPTION
## Summary

- Replace dynamic `/api/llm/functions` fetch with a static model table sourced from the shared `models.ts` registry, adding per-model pricing columns (Input / 1M, Output / 1M) and provider group headers
- Add `ALIBABA_API_KEY` to the Environment Setup section
- Add Extended Thinking callout documenting the `thinking` option for Moonshot and Alibaba providers

## Test plan

- [ ] Dev server: API Reference page loads without errors
- [ ] Environment Setup shows 7 API keys including `ALIBABA_API_KEY`
- [ ] LLM API section shows all 42 models grouped by provider with pricing columns
- [ ] Alibaba group header has NEW badge
- [ ] Extended Thinking callout appears between Returns and Available Models
- [ ] `npx tsc --noEmit` passes

Closes #261