### PR TITLE
feat(api): implement submit/status API removing migration stubs

### DIFF
--- a/src/api/__tests__/index.test.ts
+++ b/src/api/__tests__/index.test.ts
@@ -1,0 +1,372 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, mkdir, readdir } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  submitJobWithValidation,
+  PipelineOrchestrator,
+  type SubmitSuccessResult,
+  type SubmitFailureResult,
+} from "../index.ts";
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+async function readJson(filePath: string): Promise<unknown> {
+  const text = await Bun.file(filePath).text();
+  return JSON.parse(text) as unknown;
+}
+
+async function scaffoldWorkspace(tmpDir: string): Promise<void> {
+  const pipelineConfigDir = join(tmpDir, "pipeline-config", "test-pipeline");
+
+  await mkdir(pipelineConfigDir, { recursive: true });
+  await mkdir(join(pipelineConfigDir, "tasks"), { recursive: true });
+  await mkdir(join(tmpDir, "pipeline-data", "pending"), { recursive: true });
+  await mkdir(join(tmpDir, "pipeline-data", "current"), { recursive: true });
+  await mkdir(join(tmpDir, "pipeline-data", "complete"), { recursive: true });
+
+  await Bun.write(
+    join(tmpDir, "pipeline-config", "registry.json"),
+    JSON.stringify({
+      pipelines: {
+        "test-pipeline": {
+          configDir: join(tmpDir, "pipeline-config", "test-pipeline"),
+          tasksDir: join(tmpDir, "pipeline-config", "test-pipeline", "tasks"),
+        },
+      },
+    }),
+  );
+
+  await Bun.write(
+    join(pipelineConfigDir, "pipeline.json"),
+    JSON.stringify({ name: "test-pipeline", tasks: [] }),
+  );
+}
+
+// ─── submitJobWithValidation ─────────────────────────────────────────────────
+
+describe("submitJobWithValidation", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "pop-api-submit-test-"));
+    await scaffoldWorkspace(tmpDir);
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("writes seed file to pending and returns success", async () => {
+    const result = await submitJobWithValidation({
+      dataDir: tmpDir,
+      seedObject: { pipeline: "test-pipeline" },
+    });
+
+    expect(result.success).toBe(true);
+    const success = result as SubmitSuccessResult;
+    expect(success.jobId).toBeTruthy();
+    expect(success.jobName).toBe(success.jobId);
+
+    const pendingFiles = await readdir(join(tmpDir, "pipeline-data", "pending"));
+    const seedFile = pendingFiles.find((f) => f.endsWith("-seed.json"));
+    expect(seedFile).toBeDefined();
+
+    const written = await readJson(join(tmpDir, "pipeline-data", "pending", seedFile!));
+    expect(written).toEqual({ pipeline: "test-pipeline" });
+  });
+
+  it("returns seed name as jobName when provided", async () => {
+    const result = await submitJobWithValidation({
+      dataDir: tmpDir,
+      seedObject: { pipeline: "test-pipeline", name: "my-job" },
+    });
+
+    expect(result.success).toBe(true);
+    expect((result as SubmitSuccessResult).jobName).toBe("my-job");
+  });
+
+  it("rejects non-object seed with message containing 'JSON object'", async () => {
+    const result = await submitJobWithValidation({
+      dataDir: tmpDir,
+      seedObject: "not an object",
+    });
+
+    expect(result.success).toBe(false);
+    expect((result as SubmitFailureResult).message).toContain("JSON object");
+  });
+
+  it("rejects array seed with message containing 'JSON object'", async () => {
+    const result = await submitJobWithValidation({
+      dataDir: tmpDir,
+      seedObject: [1, 2, 3],
+    });
+
+    expect(result.success).toBe(false);
+    expect((result as SubmitFailureResult).message).toContain("JSON object");
+  });
+
+  it("rejects null seed with message containing 'JSON object'", async () => {
+    const result = await submitJobWithValidation({
+      dataDir: tmpDir,
+      seedObject: null,
+    });
+
+    expect(result.success).toBe(false);
+    expect((result as SubmitFailureResult).message).toContain("JSON object");
+  });
+
+  it("rejects seed missing pipeline field with message containing 'pipeline'", async () => {
+    const result = await submitJobWithValidation({
+      dataDir: tmpDir,
+      seedObject: { name: "my-job" },
+    });
+
+    expect(result.success).toBe(false);
+    expect((result as SubmitFailureResult).message).toContain("pipeline");
+  });
+
+  it("rejects seed with empty pipeline string", async () => {
+    const result = await submitJobWithValidation({
+      dataDir: tmpDir,
+      seedObject: { pipeline: "" },
+    });
+
+    expect(result.success).toBe(false);
+    expect((result as SubmitFailureResult).message).toContain("pipeline");
+  });
+
+  it("rejects non-existent pipeline slug with message containing 'not found'", async () => {
+    const result = await submitJobWithValidation({
+      dataDir: tmpDir,
+      seedObject: { pipeline: "does-not-exist" },
+    });
+
+    expect(result.success).toBe(false);
+    expect((result as SubmitFailureResult).message).toContain("not found");
+  });
+
+  it("rejects seed with empty name string", async () => {
+    const result = await submitJobWithValidation({
+      dataDir: tmpDir,
+      seedObject: { pipeline: "test-pipeline", name: "" },
+    });
+
+    expect(result.success).toBe(false);
+    expect((result as SubmitFailureResult).message).toContain("name");
+  });
+});
+
+// ─── PipelineOrchestrator.getStatus ──────────────────────────────────────────
+
+describe("PipelineOrchestrator.getStatus", () => {
+  let tmpDir: string;
+  let savedPoRoot: string | undefined;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "pop-api-status-test-"));
+    await scaffoldWorkspace(tmpDir);
+    savedPoRoot = process.env["PO_ROOT"];
+    process.env["PO_ROOT"] = tmpDir;
+  });
+
+  afterEach(async () => {
+    if (savedPoRoot === undefined) {
+      delete process.env["PO_ROOT"];
+    } else {
+      process.env["PO_ROOT"] = savedPoRoot;
+    }
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns status for job in current directory", async () => {
+    const jobId = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+    const jobDir = join(tmpDir, "pipeline-data", "current", jobId);
+    await mkdir(jobDir, { recursive: true });
+    await Bun.write(
+      join(jobDir, "tasks-status.json"),
+      JSON.stringify({
+        id: jobId,
+        name: "current-job",
+        pipeline: "test-pipeline",
+        state: "running",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        tasks: {},
+      }),
+    );
+
+    const orch = new PipelineOrchestrator({ autoStart: false });
+    const record = await orch.getStatus(jobId);
+
+    expect(record.jobId).toBe(jobId);
+    expect(record.jobName).toBe("current-job");
+    expect(record.pipeline).toBe("test-pipeline");
+  });
+
+  it("returns status for job in complete directory", async () => {
+    const jobId = "ffffffff-1111-2222-3333-444444444444";
+    const jobDir = join(tmpDir, "pipeline-data", "complete", jobId);
+    await mkdir(jobDir, { recursive: true });
+    await Bun.write(
+      join(jobDir, "tasks-status.json"),
+      JSON.stringify({
+        id: jobId,
+        name: "done-job",
+        pipeline: "test-pipeline",
+        state: "complete",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        tasks: {},
+      }),
+    );
+
+    const orch = new PipelineOrchestrator({ autoStart: false });
+    const record = await orch.getStatus(jobId);
+
+    expect(record.jobId).toBe(jobId);
+    expect(record.jobName).toBe("done-job");
+  });
+
+  it("finds job by name scan fallback", async () => {
+    const jobId = "11111111-2222-3333-4444-555555555555";
+    const jobDir = join(tmpDir, "pipeline-data", "current", jobId);
+    await mkdir(jobDir, { recursive: true });
+    await Bun.write(
+      join(jobDir, "tasks-status.json"),
+      JSON.stringify({
+        id: jobId,
+        name: "named-job",
+        pipeline: "test-pipeline",
+        state: "running",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        tasks: {},
+      }),
+    );
+
+    const orch = new PipelineOrchestrator({ autoStart: false });
+    const record = await orch.getStatus("named-job");
+
+    expect(record.jobId).toBe(jobId);
+    expect(record.jobName).toBe("named-job");
+  });
+
+  it("returns pending record for seed file in pending directory", async () => {
+    const jobId = "22222222-3333-4444-5555-666666666666";
+    await Bun.write(
+      join(tmpDir, "pipeline-data", "pending", `${jobId}-seed.json`),
+      JSON.stringify({ pipeline: "test-pipeline", name: "pending-job" }),
+    );
+
+    const orch = new PipelineOrchestrator({ autoStart: false });
+    const record = await orch.getStatus(jobId);
+
+    expect(record.jobId).toBe(jobId);
+    expect(record.jobName).toBe("pending-job");
+    expect(record.state).toBe("pending");
+    expect(record.pipeline).toBe("test-pipeline");
+    expect(record.createdAt).toBeTruthy();
+  });
+
+  it("throws for nonexistent job with message containing 'not found'", async () => {
+    const orch = new PipelineOrchestrator({ autoStart: false });
+
+    await expect(orch.getStatus("nonexistent-id")).rejects.toThrow("not found");
+  });
+});
+
+// ─── PipelineOrchestrator.listJobs ───────────────────────────────────────────
+
+describe("PipelineOrchestrator.listJobs", () => {
+  let tmpDir: string;
+  let savedPoRoot: string | undefined;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "pop-api-list-test-"));
+    await scaffoldWorkspace(tmpDir);
+    savedPoRoot = process.env["PO_ROOT"];
+    process.env["PO_ROOT"] = tmpDir;
+  });
+
+  afterEach(async () => {
+    if (savedPoRoot === undefined) {
+      delete process.env["PO_ROOT"];
+    } else {
+      process.env["PO_ROOT"] = savedPoRoot;
+    }
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns combined records from pending, current, and complete", async () => {
+    // Pending job
+    const pendingId = "aaaa-bbbb-cccc-dddd-1111";
+    await Bun.write(
+      join(tmpDir, "pipeline-data", "pending", `${pendingId}-seed.json`),
+      JSON.stringify({ pipeline: "test-pipeline", name: "pending-one" }),
+    );
+
+    // Current job
+    const currentId = "aaaa-bbbb-cccc-dddd-2222";
+    const currentDir = join(tmpDir, "pipeline-data", "current", currentId);
+    await mkdir(currentDir, { recursive: true });
+    await Bun.write(
+      join(currentDir, "tasks-status.json"),
+      JSON.stringify({
+        id: currentId,
+        name: "current-one",
+        pipeline: "test-pipeline",
+        state: "running",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        tasks: {},
+      }),
+    );
+
+    // Complete job
+    const completeId = "aaaa-bbbb-cccc-dddd-3333";
+    const completeDir = join(tmpDir, "pipeline-data", "complete", completeId);
+    await mkdir(completeDir, { recursive: true });
+    await Bun.write(
+      join(completeDir, "tasks-status.json"),
+      JSON.stringify({
+        id: completeId,
+        name: "complete-one",
+        pipeline: "test-pipeline",
+        state: "complete",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        tasks: {},
+      }),
+    );
+
+    const orch = new PipelineOrchestrator({ autoStart: false });
+    const jobs = await orch.listJobs();
+
+    expect(jobs.length).toBe(3);
+
+    const ids = jobs.map((j) => j.jobId);
+    expect(ids).toContain(pendingId);
+    expect(ids).toContain(currentId);
+    expect(ids).toContain(completeId);
+
+    const pending = jobs.find((j) => j.jobId === pendingId)!;
+    expect(pending.state).toBe("pending");
+
+    const complete = jobs.find((j) => j.jobId === completeId)!;
+    expect(complete.state).toBe("complete");
+  });
+
+  it("returns empty array when all directories are empty", async () => {
+    const orch = new PipelineOrchestrator({ autoStart: false });
+    const jobs = await orch.listJobs();
+
+    expect(jobs).toEqual([]);
+  });
+
+  it("does not throw when pipeline-data directories are missing", async () => {
+    // Remove all pipeline-data directories
+    await rm(join(tmpDir, "pipeline-data"), { recursive: true, force: true });
+
+    const orch = new PipelineOrchestrator({ autoStart: false });
+    const jobs = await orch.listJobs();
+
+    expect(jobs).toEqual([]);
+  });
+});

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,3 +1,11 @@
+import path from "node:path";
+import { mkdir, readdir, rename, stat } from "node:fs/promises";
+import { resolvePipelinePaths, getPendingSeedPath } from "../config/paths";
+import type { PipelinePaths } from "../config/paths";
+import { getPipelineConfig } from "../core/config";
+import { deriveJobStatusFromTasks } from "../config/statuses";
+import { SEED_PATTERN } from "../core/orchestrator";
+
 /** Result of a successful job submission. */
 export interface SubmitSuccessResult {
   success: true;
@@ -34,28 +42,220 @@ export interface OrchestratorOptions {
   autoStart: boolean;
 }
 
-/**
- * Validates and submits a job to the pipeline data directory.
- * Stub implementation — to be replaced when api module is fully migrated.
- */
-export async function submitJobWithValidation(
-  _opts: SubmitJobOptions
-): Promise<SubmitResult> {
-  throw new Error("submitJobWithValidation: not yet implemented");
+// ─── Private Helpers ──────────────────────────────────────────────────────────
+
+async function atomicWriteJson(filePath: string, data: unknown): Promise<void> {
+  const tmp = `${filePath}.${Date.now()}.tmp`;
+  await Bun.write(tmp, JSON.stringify(data, null, 2));
+  await rename(tmp, filePath);
 }
 
-/**
- * Pipeline orchestrator class for status/job management.
- * Stub implementation — to be replaced when api module is fully migrated.
- */
-export class PipelineOrchestrator {
-  constructor(_opts: OrchestratorOptions) {}
+function assertSeedObject(value: unknown): asserts value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error("seed must be a JSON object");
+  }
+}
 
-  async getStatus(_jobName: string): Promise<JobStatusRecord> {
-    throw new Error("PipelineOrchestrator.getStatus: not yet implemented");
+function assertPipelineSlug(value: unknown): asserts value is string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error("seed.pipeline must be a non-empty string");
+  }
+}
+
+async function safeReaddir(dirPath: string): Promise<string[]> {
+  try {
+    return await readdir(dirPath);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw err;
+  }
+}
+
+async function readJsonFile<T = unknown>(filePath: string): Promise<T> {
+  const text = await Bun.file(filePath).text();
+  return JSON.parse(text) as T;
+}
+
+function mapStatusToRecord(data: Record<string, unknown>): JobStatusRecord {
+  const { id, name, pipeline, state, createdAt, ...rest } = data;
+  return {
+    jobId: String(id ?? ""),
+    jobName: String(name ?? id ?? ""),
+    pipeline: String(pipeline ?? ""),
+    state: String(state ?? ""),
+    createdAt: String(createdAt ?? ""),
+    ...rest,
+  };
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+export async function submitJobWithValidation(
+  opts: SubmitJobOptions,
+): Promise<SubmitResult> {
+  const rootDir = path.resolve(opts.dataDir);
+
+  try {
+    assertSeedObject(opts.seedObject);
+    assertPipelineSlug(opts.seedObject["pipeline"]);
+  } catch (err) {
+    return { success: false, message: (err as Error).message };
+  }
+
+  const seed = opts.seedObject as Record<string, unknown>;
+
+  if (seed["name"] !== undefined) {
+    if (typeof seed["name"] !== "string" || seed["name"].length === 0) {
+      return { success: false, message: "seed.name must be a non-empty string if provided" };
+    }
+  }
+
+  try {
+    getPipelineConfig(seed["pipeline"] as string, rootDir);
+  } catch (err) {
+    return { success: false, message: (err as Error).message };
+  }
+
+  const jobId = crypto.randomUUID();
+  const jobName = (typeof seed["name"] === "string" && seed["name"].length > 0)
+    ? seed["name"]
+    : jobId;
+  const pendingPath = getPendingSeedPath(rootDir, jobId);
+
+  await mkdir(path.dirname(pendingPath), { recursive: true });
+
+  try {
+    await atomicWriteJson(pendingPath, opts.seedObject);
+  } catch (err) {
+    throw new Error(`failed to write seed file for job ${jobId}: ${(err as Error).message}`);
+  }
+
+  return { success: true, jobId, jobName };
+}
+
+export class PipelineOrchestrator {
+  private readonly autoStart: boolean;
+  private readonly root: string;
+  private readonly paths: PipelinePaths;
+
+  constructor(opts: OrchestratorOptions) {
+    this.autoStart = opts.autoStart;
+    this.root = path.resolve(process.env["PO_ROOT"] ?? process.cwd());
+    this.paths = resolvePipelinePaths(this.root);
+  }
+
+  async getStatus(jobName: string): Promise<JobStatusRecord> {
+    // 1. Direct jobId lookup in current, then complete
+    for (const dir of [this.paths.current, this.paths.complete]) {
+      const statusPath = path.join(dir, jobName, "tasks-status.json");
+      try {
+        const data = await readJsonFile<Record<string, unknown>>(statusPath);
+        return mapStatusToRecord(data);
+      } catch {
+        // not found here, continue
+      }
+    }
+
+    // 2. Name scan fallback
+    for (const dir of [this.paths.current, this.paths.complete]) {
+      const entries = await safeReaddir(dir);
+      for (const entry of entries) {
+        if (entry === ".gitkeep") continue;
+        const statusPath = path.join(dir, entry, "tasks-status.json");
+        try {
+          const data = await readJsonFile<Record<string, unknown>>(statusPath);
+          if (data["name"] === jobName) {
+            return mapStatusToRecord(data);
+          }
+        } catch {
+          // skip unreadable entries
+        }
+      }
+    }
+
+    // 3. Pending fallback
+    const pendingFiles = await safeReaddir(this.paths.pending);
+    for (const file of pendingFiles) {
+      const match = file.match(SEED_PATTERN);
+      if (!match) continue;
+      const id = match[1]!;
+      if (id !== jobName) continue;
+
+      const filePath = path.join(this.paths.pending, file);
+      const seed = await readJsonFile<Record<string, unknown>>(filePath);
+      const fileStat = await stat(filePath);
+      return {
+        jobId: id,
+        jobName: typeof seed["name"] === "string" ? seed["name"] : id,
+        pipeline: String(seed["pipeline"] ?? ""),
+        state: "pending",
+        createdAt: fileStat.birthtime.toISOString(),
+      };
+    }
+
+    throw new Error(`job '${jobName}' not found in pending, current, or complete`);
   }
 
   async listJobs(): Promise<JobStatusRecord[]> {
-    throw new Error("PipelineOrchestrator.listJobs: not yet implemented");
+    const results: JobStatusRecord[] = [];
+
+    // Pending jobs
+    const pendingFiles = await safeReaddir(this.paths.pending);
+    for (const file of pendingFiles) {
+      const match = file.match(SEED_PATTERN);
+      if (!match) continue;
+      const id = match[1]!;
+      const filePath = path.join(this.paths.pending, file);
+      try {
+        const seed = await readJsonFile<Record<string, unknown>>(filePath);
+        const fileStat = await stat(filePath);
+        results.push({
+          jobId: id,
+          jobName: typeof seed["name"] === "string" ? seed["name"] : id,
+          pipeline: String(seed["pipeline"] ?? ""),
+          state: "pending",
+          createdAt: fileStat.birthtime.toISOString(),
+        });
+      } catch (err) {
+        console.warn(`[api] skipping unreadable pending seed ${file}: ${(err as Error).message}`);
+      }
+    }
+
+    // Current jobs
+    const currentEntries = await safeReaddir(this.paths.current);
+    for (const entry of currentEntries) {
+      if (entry === ".gitkeep") continue;
+      const statusPath = path.join(this.paths.current, entry, "tasks-status.json");
+      try {
+        const data = await readJsonFile<Record<string, unknown>>(statusPath);
+        const tasks = data["tasks"];
+        const taskArray = tasks && typeof tasks === "object" && !Array.isArray(tasks)
+          ? Object.values(tasks as Record<string, { state: unknown }>)
+          : [];
+        const state = deriveJobStatusFromTasks(taskArray);
+        const record = mapStatusToRecord(data);
+        record.state = state;
+        results.push(record);
+      } catch (err) {
+        console.warn(`[api] skipping unreadable current job ${entry}: ${(err as Error).message}`);
+      }
+    }
+
+    // Complete jobs
+    const completeEntries = await safeReaddir(this.paths.complete);
+    for (const entry of completeEntries) {
+      if (entry === ".gitkeep") continue;
+      const statusPath = path.join(this.paths.complete, entry, "tasks-status.json");
+      try {
+        const data = await readJsonFile<Record<string, unknown>>(statusPath);
+        const record = mapStatusToRecord(data);
+        record.state = "complete";
+        results.push(record);
+      } catch (err) {
+        console.warn(`[api] skipping unreadable complete job ${entry}: ${(err as Error).message}`);
+      }
+    }
+
+    return results;
   }
 }

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach, type MockInstance } from "vitest";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, rm, mkdir, readdir } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { access } from "node:fs/promises";
@@ -286,6 +286,8 @@ describe("handleSubmit", () => {
   let tmpDir: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let exitSpy: MockInstance<any>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let cwdSpy: MockInstance<any>;
 
   beforeEach(async () => {
     tmpDir = await mkdtemp(join(tmpdir(), "pop-submit-test-"));
@@ -299,6 +301,7 @@ describe("handleSubmit", () => {
   afterEach(async () => {
     await rm(tmpDir, { recursive: true, force: true });
     exitSpy.mockRestore();
+    if (cwdSpy) cwdSpy.mockRestore();
     vi.clearAllMocks();
   });
 
@@ -314,12 +317,43 @@ describe("handleSubmit", () => {
     expect(exitSpy).toHaveBeenCalledWith(1);
   });
 
-  it("exits with 1 when submitJobWithValidation throws (API not yet implemented)", async () => {
+  it("submits a valid seed to a configured workspace", async () => {
+    // Scaffold workspace: registry, pipeline config, and pending directory
+    const configDir = join(tmpDir, "pipeline-config", "test-pipeline");
+    await mkdir(configDir, { recursive: true });
+    await mkdir(join(tmpDir, "pipeline-data", "pending"), { recursive: true });
+
+    await Bun.write(
+      join(tmpDir, "pipeline-config", "registry.json"),
+      JSON.stringify({
+        pipelines: {
+          "test-pipeline": {
+            configDir,
+            tasksDir: join(configDir, "tasks"),
+          },
+        },
+      }),
+    );
+    await Bun.write(
+      join(configDir, "pipeline.json"),
+      JSON.stringify({ name: "test-pipeline", tasks: [] }),
+    );
+
+    // Write valid seed file
     const seedPath = join(tmpDir, "seed.json");
     await Bun.write(seedPath, JSON.stringify({ pipeline: "test-pipeline" }));
-    // submitJobWithValidation throws "not yet implemented" — treated as API failure
-    await expect(handleSubmit(seedPath)).rejects.toThrow("process.exit(1)");
-    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    // Stub process.cwd() so handleSubmit resolves the workspace root
+    cwdSpy = vi.spyOn(process, "cwd").mockReturnValue(tmpDir);
+
+    await handleSubmit(seedPath);
+
+    expect(exitSpy).not.toHaveBeenCalled();
+
+    // Verify a seed file was written to pending
+    const pendingFiles = await readdir(join(tmpDir, "pipeline-data", "pending"));
+    const seedFiles = pendingFiles.filter((f) => f.endsWith("-seed.json"));
+    expect(seedFiles.length).toBe(1);
   });
 });
 


### PR DESCRIPTION
## Summary

- Replace stub implementations in `src/api/index.ts` with working `submitJobWithValidation`, `getStatus`, and `listJobs` logic
- Add seed validation (object type, pipeline slug, optional name), atomic writes to `pipeline-data/pending/`, and multi-tier job lookup across pending/current/complete directories
- Add comprehensive API test suite (17 tests) and update CLI submit test to verify real submission instead of asserting stub failure

## Test plan

- [x] `bun test src/api/__tests__/index.test.ts` — 17 pass
- [x] `bun test src/cli/__tests__/index.test.ts` — 36 pass
- [ ] Manual: `bun src/cli/index.ts submit <seed-file>` against a configured workspace
- [ ] Manual: `bun src/cli/index.ts status [job-name]` returns job data

Closes #262