### PR TITLE
Fix pipeline progress showing 100% for in-flight jobs

### DIFF
--- a/src/core/status-writer.ts
+++ b/src/core/status-writer.ts
@@ -212,13 +212,10 @@ export function resetJobFromTask(jobDir: string, fromTask: string, options?: Res
 
   return writeJobStatus(jobDir, (snapshot) => {
     const taskKeys = Object.keys(snapshot.tasks);
-    const totalCount = taskKeys.length;
-    const doneCount = taskKeys.filter((k) => snapshot.tasks[k]!.state === "done").length;
 
     snapshot.state = "pending";
     snapshot.current = null;
     snapshot.currentStage = null;
-    snapshot.progress = totalCount > 0 ? (doneCount / totalCount) * 100 : 0;
 
     const fromIndex = taskKeys.indexOf(fromTask);
     const resetKeys = fromIndex === -1 ? [] : taskKeys.slice(fromIndex);

--- a/src/core/task-runner.ts
+++ b/src/core/task-runner.ts
@@ -795,7 +795,17 @@ export async function runPipeline(
 
   // Write done status (best-effort)
   try {
+    const lastStage = KNOWN_STAGES[KNOWN_STAGES.length - 1];
+    const doneProgress = computeDeterministicProgress(
+      pipelineTasks ?? [taskName],
+      taskName,
+      lastStage,
+    );
     await writeJobStatus(jobDir, (snapshot: StatusSnapshot) => {
+      snapshot.state = TaskState.DONE;
+      snapshot.progress = doneProgress;
+      snapshot.current = null;
+      snapshot.currentStage = null;
       if (!snapshot.tasks[taskName]) snapshot.tasks[taskName] = {};
       snapshot.tasks[taskName]!.state = TaskState.DONE;
       snapshot.tasks[taskName]!.currentStage = null;

--- a/src/ui/client/__tests__/job-adapter.test.ts
+++ b/src/ui/client/__tests__/job-adapter.test.ts
@@ -102,6 +102,32 @@ describe("job adapter", () => {
     expect(job.doneCount).toBe(1);
   });
 
+  it("computes progress from pipelineConfig taskCount, ignoring api progress", () => {
+    const job = adaptJobSummary({
+      jobId: "job-1",
+      progress: 100,
+      tasks: {
+        build: { state: "done" },
+        test: { state: "done" },
+        lint: { state: "done" },
+      },
+      pipelineConfig: {
+        tasks: [
+          { name: "build" },
+          { name: "test" },
+          { name: "lint" },
+          { name: "deploy" },
+          { name: "verify" },
+          { name: "publish" },
+        ],
+      },
+    });
+
+    expect(job.taskCount).toBe(6);
+    expect(job.doneCount).toBe(3);
+    expect(job.progress).toBe(50);
+  });
+
   it("falls back to taskList length when pipelineConfig is absent", () => {
     const job = adaptJobSummary({
       jobId: "job-1",

--- a/src/ui/client/__tests__/useJobDetailWithUpdates.test.ts
+++ b/src/ui/client/__tests__/useJobDetailWithUpdates.test.ts
@@ -68,6 +68,49 @@ describe("useJobDetailWithUpdates helpers", () => {
     expect(extractJobDetail({ ok: true, data: { jobId: "job-1" } })).toEqual({ jobId: "job-1" });
   });
 
+  it("uses pipelineConfig.tasks.length as authoritative denominator", () => {
+    const detail: NormalizedJobDetail = {
+      ...makeDetail("job-1"),
+      pipelineConfig: {
+        tasks: ["a", "b", "c", "d", "e", "f"],
+      },
+      taskCount: 6,
+      tasks: {
+        a: { name: "a", state: "done", startedAt: null, endedAt: null, files: { artifacts: [], logs: [], tmp: [] } },
+        b: { name: "b", state: "done", startedAt: null, endedAt: null, files: { artifacts: [], logs: [], tmp: [] } },
+        c: { name: "c", state: "done", startedAt: null, endedAt: null, files: { artifacts: [], logs: [], tmp: [] } },
+        d: { name: "d", state: "running", startedAt: null, endedAt: null, files: { artifacts: [], logs: [], tmp: [] } },
+      },
+    };
+
+    const next = applyDetailEvent(detail, {
+      type: "task:updated",
+      data: { jobId: "job-1", taskName: "d", task: { state: "running" } },
+    });
+
+    expect(next.taskCount).toBe(6);
+    expect(next.doneCount).toBe(3);
+    expect(next.progress).toBe(50);
+  });
+
+  it("falls back to local task list length without pipelineConfig", () => {
+    const detail: NormalizedJobDetail = {
+      ...makeDetail("job-1"),
+      pipelineConfig: undefined,
+    };
+
+    const next = applyDetailEvent(detail, {
+      type: "task:updated",
+      data: { jobId: "job-1", taskName: "build", task: { state: "done" } },
+    });
+
+    expect(next.taskCount).toBe(2);
+    expect(next.doneCount).toBe(1);
+    expect(next.progress).toBe(50);
+    expect(next.progress).toBeGreaterThanOrEqual(0);
+    expect(next.progress).toBeLessThanOrEqual(100);
+  });
+
   it("exports the detail debounce constant", () => {
     expect(REFRESH_DEBOUNCE_MS).toBe(200);
   });

--- a/src/ui/client/adapters/job-adapter.ts
+++ b/src/ui/client/adapters/job-adapter.ts
@@ -140,10 +140,10 @@ function adaptBaseJob(apiJob: Record<string, unknown>): NormalizedJobSummary {
   const inferredStatus = deriveJobStatusFromTasks(taskList);
   const status = normalizeJobStatus(apiJob["status"] ?? inferredStatus);
   const progress = pipelineTaskArray
-    ? (taskCount === 0 ? 0 : Math.floor((doneCount / taskCount) * 100))
+    ? (taskCount === 0 ? 0 : Math.min(100, Math.floor((doneCount / taskCount) * 100)))
     : typeof apiJob["progress"] === "number"
       ? apiJob["progress"]
-      : taskCount === 0 ? 0 : Math.floor((doneCount / taskCount) * 100);
+      : taskCount === 0 ? 0 : Math.min(100, Math.floor((doneCount / taskCount) * 100));
 
   return {
     id: typeof apiJob["id"] === "string" ? apiJob["id"] : String(apiJob["jobId"] ?? ""),

--- a/src/ui/client/adapters/job-adapter.ts
+++ b/src/ui/client/adapters/job-adapter.ts
@@ -139,9 +139,11 @@ function adaptBaseJob(apiJob: Record<string, unknown>): NormalizedJobSummary {
   const taskCount = pipelineTaskArray ? pipelineTaskArray.length : taskList.length;
   const inferredStatus = deriveJobStatusFromTasks(taskList);
   const status = normalizeJobStatus(apiJob["status"] ?? inferredStatus);
-  const progress = typeof apiJob["progress"] === "number"
-    ? apiJob["progress"]
-    : taskCount === 0 ? 0 : Math.floor((doneCount / taskCount) * 100);
+  const progress = pipelineTaskArray
+    ? (taskCount === 0 ? 0 : Math.floor((doneCount / taskCount) * 100))
+    : typeof apiJob["progress"] === "number"
+      ? apiJob["progress"]
+      : taskCount === 0 ? 0 : Math.floor((doneCount / taskCount) * 100);
 
   return {
     id: typeof apiJob["id"] === "string" ? apiJob["id"] : String(apiJob["jobId"] ?? ""),

--- a/src/ui/client/hooks/useJobDetailWithUpdates.ts
+++ b/src/ui/client/hooks/useJobDetailWithUpdates.ts
@@ -36,7 +36,7 @@ function recomputeProgress(detail: NormalizedJobDetail): NormalizedJobDetail {
     ...detail,
     doneCount,
     taskCount,
-    progress: taskCount === 0 ? 0 : Math.floor((doneCount / taskCount) * 100),
+    progress: taskCount === 0 ? 0 : Math.min(100, Math.floor((doneCount / taskCount) * 100)),
     updatedAt: new Date().toISOString(),
   };
 }

--- a/src/ui/client/hooks/useJobDetailWithUpdates.ts
+++ b/src/ui/client/hooks/useJobDetailWithUpdates.ts
@@ -22,10 +22,16 @@ export function extractJobDetail(payload: unknown): Record<string, unknown> | nu
   return null;
 }
 
+function getPipelineTaskCount(detail: NormalizedJobDetail): number | null {
+  const config = detail.pipelineConfig;
+  if (config && Array.isArray(config["tasks"])) return config["tasks"].length;
+  return null;
+}
+
 function recomputeProgress(detail: NormalizedJobDetail): NormalizedJobDetail {
   const tasks = Object.values(detail.tasks);
   const doneCount = tasks.filter((task) => task.state === "done").length;
-  const taskCount = tasks.length;
+  const taskCount = getPipelineTaskCount(detail) ?? tasks.length;
   return {
     ...detail,
     doneCount,

--- a/src/ui/state/transformers/__tests__/status-transformer.test.ts
+++ b/src/ui/state/transformers/__tests__/status-transformer.test.ts
@@ -52,6 +52,39 @@ describe("status-transformer", () => {
     warn.mockRestore();
   });
 
+  it("computes progress from tasks alone, ignoring any previously persisted value", () => {
+    const result = computeJobStatus({
+      a: { state: "done" },
+      b: { state: "done" },
+      c: { state: "running" },
+      d: { state: "pending" },
+    });
+
+    expect(result).toEqual({ status: "running", progress: 50 });
+  });
+
+  it("returns pending with zero progress for empty task list", () => {
+    expect(computeJobStatus([])).toEqual({ status: "pending", progress: 0 });
+  });
+
+  it("transformJobStatus derives progress from tasks, not record.progress", () => {
+    const job = transformJobStatus(
+      {
+        title: "Test",
+        progress: 100,
+        tasks: {
+          a: { state: "done" },
+          b: { state: "running" },
+        },
+      },
+      "job-1",
+      "current",
+    );
+
+    expect(job?.progress).toBe(50);
+    expect(job?.status).toBe("running");
+  });
+
   it("filters failed reads and computes transformation stats", () => {
     const transformed = transformMultipleJobs([
       { ok: true, data: { tasks: { a: { state: "done" } } }, jobId: "job-1", location: "current" },

--- a/src/ui/state/transformers/status-transformer.ts
+++ b/src/ui/state/transformers/status-transformer.ts
@@ -52,8 +52,7 @@ function getStatusValue(status: string): string {
   return status === "failed" ? "error" : status;
 }
 
-function getProgress(tasks: CanonicalTask[], existingProgress?: number): number {
-  if (typeof existingProgress === "number") return existingProgress;
+function getProgress(tasks: CanonicalTask[]): number {
   if (tasks.length === 0) return 0;
 
   const done = tasks.filter((task) => task.state === "done").length;
@@ -100,7 +99,7 @@ function getCosts(raw: Record<string, unknown>): Record<string, unknown> {
   return { totalCost, totalTokens, totalInputTokens, totalOutputTokens };
 }
 
-export function computeJobStatus(tasksInput: unknown, existingProgress?: number): ComputedStatus {
+export function computeJobStatus(tasksInput: unknown): ComputedStatus {
   const tasks = Object.values(transformTasks(tasksInput));
   if (tasks.length === 0) {
     return { status: "pending", progress: 0 };
@@ -108,7 +107,7 @@ export function computeJobStatus(tasksInput: unknown, existingProgress?: number)
 
   return {
     status: getStatusValue(deriveJobStatusFromTasks(tasks)),
-    progress: getProgress(tasks, existingProgress),
+    progress: getProgress(tasks),
   };
 }
 
@@ -139,7 +138,7 @@ export function transformJobStatus(raw: unknown, jobId: string, location: string
   }
 
   const tasks = transformTasks(record["tasks"]);
-  const computed = computeJobStatus(tasks, typeof record["progress"] === "number" ? record["progress"] : undefined);
+  const computed = computeJobStatus(tasks);
   const title = getTitle(record, jobId);
 
   return {

--- a/tests/core/status-writer.test.ts
+++ b/tests/core/status-writer.test.ts
@@ -732,13 +732,27 @@ describe("resetJobFromTask", () => {
     expect(snapshot.tasks["D"]!.refinementAttempts).toBe(0);
   });
 
-  test("progress reflects done count before any reset", async () => {
+  test("does not recompute or stomp progress from snapshot task-map size", async () => {
     const dir = await makeTempDir();
     await setupSnapshot(dir);
 
-    // Before reset: A=done, B=done, C=failed, D=pending → 2 done out of 4 = 50%
+    // setupSnapshot does not set progress, so it remains undefined.
+    // resetJobFromTask must not derive progress from the snapshot task map.
     const snapshot = await resetJobFromTask(dir, "C");
-    expect(snapshot.progress).toBe(50);
+    expect(snapshot.progress).toBeUndefined();
+  });
+
+  test("preserves existing progress value without overwriting", async () => {
+    const dir = await makeTempDir();
+    await setupSnapshot(dir);
+
+    // Set an explicit progress value before reset
+    await writeJobStatus(dir, (s) => {
+      s.progress = 25;
+    });
+
+    const snapshot = await resetJobFromTask(dir, "C");
+    expect(snapshot.progress).toBe(25);
   });
 
   test("files arrays on all tasks are preserved", async () => {

--- a/tests/core/task-runner.test.ts
+++ b/tests/core/task-runner.test.ts
@@ -16,6 +16,7 @@ import {
   runPipeline,
   runPipelineWithModelRouting,
   decideTransition,
+  computeDeterministicProgress,
   KNOWN_STAGES,
 } from "../../src/core/task-runner";
 import type {
@@ -592,6 +593,54 @@ describe("runPipeline", () => {
     const failure = result as PipelineFailure;
     expect(failure.failedStage).toBe("inference");
     expect(failure.error.message).toMatch(/type conflict/);
+  });
+
+  test("non-final task completion writes deterministic progress less than 100", async () => {
+    modulePath = await writeTaskModule(`
+      export async function ingestion(ctx) {
+        return { output: "data", flags: {} };
+      }
+    `);
+
+    const pipelineTasks = ["test-task", "task2", "task3", "task4"];
+    const result = await runPipeline(modulePath, makeContext({ pipelineTasks }));
+    expect(result.ok).toBe(true);
+
+    const lastStage = KNOWN_STAGES[KNOWN_STAGES.length - 1];
+    const expected = computeDeterministicProgress(pipelineTasks, "test-task", lastStage);
+    expect(expected).toBeLessThan(100);
+
+    const snapshot = await Bun.file(statusPath).json();
+    expect(snapshot.progress).toBe(expected);
+  });
+
+  test("final task completion writes progress exactly 100", async () => {
+    modulePath = await writeTaskModule(`
+      export async function ingestion(ctx) {
+        return { output: "data", flags: {} };
+      }
+    `);
+
+    const pipelineTasks = ["task1", "task2", "task3", "test-task"];
+    const result = await runPipeline(modulePath, makeContext({ pipelineTasks }));
+    expect(result.ok).toBe(true);
+
+    const snapshot = await Bun.file(statusPath).json();
+    expect(snapshot.progress).toBe(100);
+  });
+
+  test("single-task pipeline completion writes progress exactly 100", async () => {
+    modulePath = await writeTaskModule(`
+      export async function ingestion(ctx) {
+        return { output: "data", flags: {} };
+      }
+    `);
+
+    const result = await runPipeline(modulePath, makeContext({ pipelineTasks: ["test-task"] }));
+    expect(result.ok).toBe(true);
+
+    const snapshot = await Bun.file(statusPath).json();
+    expect(snapshot.progress).toBe(100);
   });
 });
 


### PR DESCRIPTION
Closes #277

## Summary

- **Remove persisted-progress passthrough** from `computeJobStatus` / `getProgress` in the status transformer so stale disk values never override task-derived progress
- **Write deterministic progress** at task completion in `task-runner.ts` using `computeDeterministicProgress` instead of hardcoded `100`
- **Stop `resetJobFromTask` from stomping progress** — it lacked pipeline cardinality and produced incorrect values from snapshot-local task counts
- **Use `pipelineConfig.tasks.length`** as the authoritative denominator in the detail recompute path and job adapter, falling back to local task list length
- **Derive `taskCount` from pipeline config** in `job-adapter.ts` for consistent "X of Y" display

## Test plan

- [ ] Verify 4-task pipeline: intermediate tasks show progress < 100%, final task shows exactly 100%
- [ ] Verify single-task pipeline: completion shows exactly 100%
- [ ] Verify reset flow does not overwrite progress
- [ ] Verify SSE detail updates recompute progress using pipeline config length
- [ ] Verify empty task list produces progress 0, not NaN/Infinity