### PR TITLE
Implement real task start for stalled pending pipeline tasks

### DIFF
--- a/src/ui/server/__tests__/job-control-endpoints.test.ts
+++ b/src/ui/server/__tests__/job-control-endpoints.test.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import type { Subprocess } from "bun";
 
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { initPATHS, resetPATHS } from "../config-bridge-node";
 import { handleJobRestart, handleJobStop, handleTaskStart } from "../endpoints/job-control-endpoints";
@@ -34,6 +34,25 @@ async function setupJob(
   return jobDir;
 }
 
+async function setupPipelineConfig(root: string, slug: string, tasks: string[]): Promise<void> {
+  const configDir = path.join(root, "pipeline-config", slug);
+  await mkdir(configDir, { recursive: true });
+  await writeFile(path.join(configDir, "pipeline.json"), JSON.stringify({ name: slug, tasks }));
+  await writeFile(path.join(root, "pipeline-config", "registry.json"), JSON.stringify({
+    pipelines: {
+      [slug]: {},
+    },
+  }));
+}
+
+function mockRunnerSpawn(pid = 424242) {
+  const proc = {
+    pid,
+    unref: vi.fn(),
+  } as unknown as Subprocess;
+  return vi.spyOn(Bun, "spawn").mockReturnValue(proc);
+}
+
 function spawnSleeper(): Subprocess {
   const proc = Bun.spawn(["sleep", "60"], {
     stdout: "ignore",
@@ -45,6 +64,7 @@ function spawnSleeper(): Subprocess {
 }
 
 afterEach(async () => {
+  vi.restoreAllMocks();
   resetPATHS();
   for (const proc of childProcs.splice(0)) {
     try { proc.kill(); } catch {}
@@ -340,6 +360,8 @@ describe("handleJobRestart", () => {
       files: { artifacts: [], logs: [], tmp: [] },
     });
 
+    mockRunnerSpawn();
+
     const req = new Request("http://localhost/api/jobs/restart-3/restart", { method: "POST" });
     const res = await handleJobRestart(req, "restart-3", root);
     const body = await res.json() as Record<string, unknown>;
@@ -494,15 +516,18 @@ describe("handleTaskStart", () => {
   it("returns 202 and spawns runner when target task is pending and dependencies are done", async () => {
     const root = await makeTempRoot();
     initPATHS(root);
+    await setupPipelineConfig(root, "task-start-ok-pipeline", ["research", "analysis"]);
+    const spawnSpy = mockRunnerSpawn(12345);
 
     const jobDir = await setupJob(root, "task-start-ok", {
       id: "task-start-ok",
+      pipeline: "task-start-ok-pipeline",
       state: "pending",
       current: null,
       currentStage: null,
       tasks: {
-        research: { state: "done", currentStage: null },
         analysis: { state: "pending", currentStage: null },
+        research: { state: "done", currentStage: null },
       },
       files: { artifacts: [], logs: [], tmp: [] },
     });
@@ -511,7 +536,18 @@ describe("handleTaskStart", () => {
     const snapshotBefore = await Bun.file(statusPath).text();
 
     const req = new Request("http://localhost/api/jobs/task-start-ok/tasks/analysis/start", { method: "POST" });
-    const res = await handleTaskStart(req, "task-start-ok", "analysis", root);
+    const originalRunSingleTask = process.env["PO_RUN_SINGLE_TASK"];
+    process.env["PO_RUN_SINGLE_TASK"] = "true";
+    let res: Response;
+    try {
+      res = await handleTaskStart(req, "task-start-ok", "analysis", root);
+    } finally {
+      if (originalRunSingleTask === undefined) {
+        delete process.env["PO_RUN_SINGLE_TASK"];
+      } else {
+        process.env["PO_RUN_SINGLE_TASK"] = originalRunSingleTask;
+      }
+    }
     const body = await res.json() as Record<string, unknown>;
 
     expect(res.status).toBe(202);
@@ -526,26 +562,100 @@ describe("handleTaskStart", () => {
 
     const snapshotAfter = await Bun.file(statusPath).text();
     expect(snapshotAfter).toBe(snapshotBefore);
+
+    expect(spawnSpy).toHaveBeenCalledTimes(1);
+    const spawnOptions = spawnSpy.mock.calls[0]![0] as unknown as {
+      cmd: string[];
+      env: Record<string, string | undefined>;
+    };
+    expect(spawnOptions.cmd[0]).toBe("bun");
+    expect(spawnOptions.cmd[1]).toBe("run");
+    expect(spawnOptions.cmd[2]).toContain("pipeline-runner.ts");
+    expect(spawnOptions.cmd[3]).toBe("task-start-ok");
+    expect(spawnOptions.env["PO_ROOT"]).toBe(root);
+    expect(spawnOptions.env["PO_START_FROM_TASK"]).toBe("analysis");
+    expect(spawnOptions.env["PO_RUN_SINGLE_TASK"]).toBeUndefined();
+    await expect(Bun.file(path.join(jobDir, "runner.pid")).text()).resolves.toBe("12345\n");
+  });
+
+  it("returns 409 job_running on an immediate second start after writing runner.pid", async () => {
+    const root = await makeTempRoot();
+    initPATHS(root);
+    await setupPipelineConfig(root, "task-start-duplicate-pipeline", ["research", "analysis"]);
+    const spawnSpy = mockRunnerSpawn(process.pid);
+
+    await setupJob(root, "task-start-duplicate", {
+      id: "task-start-duplicate",
+      pipeline: "task-start-duplicate-pipeline",
+      state: "pending",
+      current: null,
+      currentStage: null,
+      tasks: {
+        research: { state: "done", currentStage: null },
+        analysis: { state: "pending", currentStage: null },
+      },
+      files: { artifacts: [], logs: [], tmp: [] },
+    });
+
+    const firstReq = new Request("http://localhost/api/jobs/task-start-duplicate/tasks/analysis/start", { method: "POST" });
+    const firstRes = await handleTaskStart(firstReq, "task-start-duplicate", "analysis", root);
+    expect(firstRes.status).toBe(202);
+
+    const secondReq = new Request("http://localhost/api/jobs/task-start-duplicate/tasks/analysis/start", { method: "POST" });
+    const secondRes = await handleTaskStart(secondReq, "task-start-duplicate", "analysis", root);
+    const secondBody = await secondRes.json() as Record<string, unknown>;
+
+    expect(secondRes.status).toBe(409);
+    expect(secondBody["code"]).toBe("job_running");
+    expect(spawnSpy).toHaveBeenCalledTimes(1);
   });
 
   it("returns 412 dependencies_not_satisfied when an earlier task is \"pending\"", async () => {
     const root = await makeTempRoot();
     initPATHS(root);
+    await setupPipelineConfig(root, "task-start-deps-pipeline", ["research", "analysis"]);
 
     await setupJob(root, "task-start-deps", {
       id: "task-start-deps",
+      pipeline: "task-start-deps-pipeline",
       state: "pending",
       current: null,
       currentStage: null,
       tasks: {
-        research: { state: "pending", currentStage: null },
         analysis: { state: "pending", currentStage: null },
+        research: { state: "pending", currentStage: null },
       },
       files: { artifacts: [], logs: [], tmp: [] },
     });
 
     const req = new Request("http://localhost/api/jobs/task-start-deps/tasks/analysis/start", { method: "POST" });
     const res = await handleTaskStart(req, "task-start-deps", "analysis", root);
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(res.status).toBe(412);
+    expect(body["code"]).toBe("dependencies_not_satisfied");
+  });
+
+  it("returns 412 dependencies_not_satisfied when an earlier task is \"failed\"", async () => {
+    const root = await makeTempRoot();
+    initPATHS(root);
+    await setupPipelineConfig(root, "task-start-failed-deps-pipeline", ["research", "analysis"]);
+
+    await setupJob(root, "task-start-failed-deps", {
+      id: "task-start-failed-deps",
+      pipeline: "task-start-failed-deps-pipeline",
+      state: "failed",
+      current: null,
+      currentStage: null,
+      tasks: {
+        analysis: { state: "pending", currentStage: null },
+        research: { state: "failed", currentStage: null },
+      },
+      files: { artifacts: [], logs: [], tmp: [] },
+    });
+
+    const req = new Request("http://localhost/api/jobs/task-start-failed-deps/tasks/analysis/start", { method: "POST" });
+    const res = await handleTaskStart(req, "task-start-failed-deps", "analysis", root);
     const body = await res.json() as Record<string, unknown>;
 
     expect(res.status).toBe(412);
@@ -582,6 +692,7 @@ describe("stop → restart integration", () => {
     expect(snapshot!.tasks["research"]!.state).toBe("pending");
 
     // Restart should now succeed (no 409 deadlock)
+    mockRunnerSpawn();
     const restartReq = new Request("http://localhost/api/jobs/integ-1/restart", { method: "POST" });
     const restartRes = await handleJobRestart(restartReq, "integ-1", root);
     const restartBody = await restartRes.json() as Record<string, unknown>;
@@ -607,6 +718,8 @@ describe("stop → restart integration", () => {
       },
       files: { artifacts: [], logs: [], tmp: [] },
     }, 999999);
+
+    mockRunnerSpawn();
 
     const req = new Request("http://localhost/api/jobs/integ-2/restart", { method: "POST" });
     const res = await handleJobRestart(req, "integ-2", root);
@@ -701,6 +814,7 @@ describe("stop → restart integration", () => {
     expect(afterStop!.tasks["synthesis"]!.state).toBe("pending");
 
     // Restart with clean-slate resets everything
+    mockRunnerSpawn();
     const restartReq = new Request("http://localhost/api/jobs/integ-5/restart", { method: "POST" });
     const restartRes = await handleJobRestart(restartReq, "integ-5", root);
     const restartBody = await restartRes.json() as Record<string, unknown>;

--- a/src/ui/server/__tests__/job-control-endpoints.test.ts
+++ b/src/ui/server/__tests__/job-control-endpoints.test.ts
@@ -6,7 +6,7 @@ import type { Subprocess } from "bun";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { initPATHS, resetPATHS } from "../config-bridge-node";
-import { handleJobRestart, handleJobStop } from "../endpoints/job-control-endpoints";
+import { handleJobRestart, handleJobStop, handleTaskStart } from "../endpoints/job-control-endpoints";
 import { readJobStatus } from "../../../core/status-writer";
 
 const tempRoots: string[] = [];
@@ -347,6 +347,172 @@ describe("handleJobRestart", () => {
     expect(res.status).toBe(202);
     expect(body["ok"]).toBe(true);
     expect(body["mode"]).toBe("clean-slate");
+  });
+});
+
+describe("handleTaskStart", () => {
+  it("returns 404 JOB_NOT_FOUND when job exists in neither current/ nor complete/", async () => {
+    const root = await makeTempRoot();
+    initPATHS(root);
+
+    const req = new Request("http://localhost/api/jobs/missing/tasks/research/start", { method: "POST" });
+    const res = await handleTaskStart(req, "missing", "research", root);
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(res.status).toBe(404);
+    expect(body["code"]).toBe("JOB_NOT_FOUND");
+  });
+
+  it("returns 409 unsupported_lifecycle when job exists only in complete/, leaving job directory in place", async () => {
+    const root = await makeTempRoot();
+    initPATHS(root);
+
+    const completeDir = path.join(root, "pipeline-data", "complete", "task-start-complete");
+    await mkdir(completeDir, { recursive: true });
+    await writeFile(path.join(completeDir, "tasks-status.json"), JSON.stringify({
+      id: "task-start-complete",
+      state: "complete",
+      current: null,
+      currentStage: null,
+      tasks: {
+        research: { state: "done", currentStage: null },
+      },
+      files: { artifacts: [], logs: [], tmp: [] },
+    }));
+
+    const req = new Request("http://localhost/api/jobs/task-start-complete/tasks/research/start", { method: "POST" });
+    const res = await handleTaskStart(req, "task-start-complete", "research", root);
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(res.status).toBe(409);
+    expect(body["code"]).toBe("unsupported_lifecycle");
+
+    const stillThere = await Bun.file(path.join(completeDir, "tasks-status.json")).exists();
+    expect(stillThere).toBe(true);
+
+    const movedToCurrent = await Bun.file(path.join(root, "pipeline-data", "current", "task-start-complete", "tasks-status.json")).exists();
+    expect(movedToCurrent).toBe(false);
+  });
+
+  it("returns 409 job_running when runner.pid points to a live process", async () => {
+    const root = await makeTempRoot();
+    initPATHS(root);
+
+    const proc = spawnSleeper();
+
+    await setupJob(root, "task-start-live", {
+      id: "task-start-live",
+      state: "running",
+      current: "research",
+      currentStage: "prompt",
+      tasks: {
+        research: { state: "running", currentStage: "prompt" },
+      },
+      files: { artifacts: [], logs: [], tmp: [] },
+    }, proc.pid);
+
+    const req = new Request("http://localhost/api/jobs/task-start-live/tasks/research/start", { method: "POST" });
+    const res = await handleTaskStart(req, "task-start-live", "research", root);
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(res.status).toBe(409);
+    expect(body["code"]).toBe("job_running");
+  });
+
+  it("returns 409 job_running when snapshot has a task in \"running\" state and PID is dead", async () => {
+    const root = await makeTempRoot();
+    initPATHS(root);
+
+    await setupJob(root, "task-start-stale", {
+      id: "task-start-stale",
+      state: "running",
+      current: "research",
+      currentStage: "prompt",
+      tasks: {
+        research: { state: "running", currentStage: "prompt" },
+        analysis: { state: "pending", currentStage: null },
+      },
+      files: { artifacts: [], logs: [], tmp: [] },
+    }, 999999);
+
+    const req = new Request("http://localhost/api/jobs/task-start-stale/tasks/analysis/start", { method: "POST" });
+    const res = await handleTaskStart(req, "task-start-stale", "analysis", root);
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(res.status).toBe(409);
+    expect(body["code"]).toBe("job_running");
+  });
+
+  it("returns 404 task_not_found for an unknown taskId", async () => {
+    const root = await makeTempRoot();
+    initPATHS(root);
+
+    await setupJob(root, "task-start-unknown", {
+      id: "task-start-unknown",
+      state: "pending",
+      current: null,
+      currentStage: null,
+      tasks: {
+        research: { state: "done", currentStage: null },
+        analysis: { state: "pending", currentStage: null },
+      },
+      files: { artifacts: [], logs: [], tmp: [] },
+    });
+
+    const req = new Request("http://localhost/api/jobs/task-start-unknown/tasks/synthesis/start", { method: "POST" });
+    const res = await handleTaskStart(req, "task-start-unknown", "synthesis", root);
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(res.status).toBe(404);
+    expect(body["code"]).toBe("task_not_found");
+  });
+
+  it("returns 422 task_not_pending when target task is \"done\"", async () => {
+    const root = await makeTempRoot();
+    initPATHS(root);
+
+    await setupJob(root, "task-start-done", {
+      id: "task-start-done",
+      state: "pending",
+      current: null,
+      currentStage: null,
+      tasks: {
+        research: { state: "done", currentStage: null },
+        analysis: { state: "pending", currentStage: null },
+      },
+      files: { artifacts: [], logs: [], tmp: [] },
+    });
+
+    const req = new Request("http://localhost/api/jobs/task-start-done/tasks/research/start", { method: "POST" });
+    const res = await handleTaskStart(req, "task-start-done", "research", root);
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(res.status).toBe(422);
+    expect(body["code"]).toBe("task_not_pending");
+  });
+
+  it("returns 412 dependencies_not_satisfied when an earlier task is \"pending\"", async () => {
+    const root = await makeTempRoot();
+    initPATHS(root);
+
+    await setupJob(root, "task-start-deps", {
+      id: "task-start-deps",
+      state: "pending",
+      current: null,
+      currentStage: null,
+      tasks: {
+        research: { state: "pending", currentStage: null },
+        analysis: { state: "pending", currentStage: null },
+      },
+      files: { artifacts: [], logs: [], tmp: [] },
+    });
+
+    const req = new Request("http://localhost/api/jobs/task-start-deps/tasks/analysis/start", { method: "POST" });
+    const res = await handleTaskStart(req, "task-start-deps", "analysis", root);
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(res.status).toBe(412);
+    expect(body["code"]).toBe("dependencies_not_satisfied");
   });
 });
 

--- a/src/ui/server/__tests__/job-control-endpoints.test.ts
+++ b/src/ui/server/__tests__/job-control-endpoints.test.ts
@@ -491,6 +491,43 @@ describe("handleTaskStart", () => {
     expect(body["code"]).toBe("task_not_pending");
   });
 
+  it("returns 202 and spawns runner when target task is pending and dependencies are done", async () => {
+    const root = await makeTempRoot();
+    initPATHS(root);
+
+    const jobDir = await setupJob(root, "task-start-ok", {
+      id: "task-start-ok",
+      state: "pending",
+      current: null,
+      currentStage: null,
+      tasks: {
+        research: { state: "done", currentStage: null },
+        analysis: { state: "pending", currentStage: null },
+      },
+      files: { artifacts: [], logs: [], tmp: [] },
+    });
+
+    const statusPath = path.join(jobDir, "tasks-status.json");
+    const snapshotBefore = await Bun.file(statusPath).text();
+
+    const req = new Request("http://localhost/api/jobs/task-start-ok/tasks/analysis/start", { method: "POST" });
+    const res = await handleTaskStart(req, "task-start-ok", "analysis", root);
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(res.status).toBe(202);
+    expect(body).toEqual({
+      ok: true,
+      jobId: "task-start-ok",
+      taskId: "analysis",
+      action: "start",
+      lifecycle: "current",
+      spawned: true,
+    });
+
+    const snapshotAfter = await Bun.file(statusPath).text();
+    expect(snapshotAfter).toBe(snapshotBefore);
+  });
+
   it("returns 412 dependencies_not_satisfied when an earlier task is \"pending\"", async () => {
     const root = await makeTempRoot();
     initPATHS(root);

--- a/src/ui/server/endpoints/job-control-endpoints.ts
+++ b/src/ui/server/endpoints/job-control-endpoints.ts
@@ -450,9 +450,21 @@ export async function handleTaskStart(
       }
     }
 
-    await mkdir(path.join(dataDir, "pipeline-data"), { recursive: true });
-    await spawnDetached(["bun", "-e", "process.exit(0)"]);
-    return sendJson(202, { ok: true, jobId, taskId, action: "start", lifecycle });
+    const env: Record<string, string | undefined> = {
+      ...(process.env as Record<string, string>),
+      PO_ROOT: dataDir,
+      PO_START_FROM_TASK: taskId,
+    };
+    await spawnDetached(["bun", "run", RUNNER_PATH, jobId], env);
+
+    return sendJson(202, {
+      ok: true,
+      jobId,
+      taskId,
+      action: "start",
+      lifecycle: "current",
+      spawned: true,
+    });
   } finally {
     endStart(jobId);
   }

--- a/src/ui/server/endpoints/job-control-endpoints.ts
+++ b/src/ui/server/endpoints/job-control-endpoints.ts
@@ -6,6 +6,7 @@ import { Constants } from "../config-bridge-node";
 import { sendJson } from "../utils/http-utils";
 import { getJobDirectoryPath } from "../../../config/paths";
 import { deriveJobStatusFromTasks } from "../../../config/statuses";
+import { getPipelineConfig } from "../../../core/config";
 import {
   readJobStatus,
   resetJobToCleanSlate,
@@ -31,15 +32,43 @@ function end(set: Set<string>, jobId: string): void {
   set.delete(jobId);
 }
 
-async function spawnDetached(args: string[], env?: Record<string, string | undefined>): Promise<void> {
+function buildRunnerEnv(
+  dataDir: string,
+  opts: { startFromTask?: string; runSingleTask?: boolean } = {},
+): Record<string, string | undefined> {
+  const env: Record<string, string | undefined> = {
+    ...(process.env as Record<string, string>),
+    PO_ROOT: dataDir,
+  };
+
+  delete env["PO_START_FROM_TASK"];
+  delete env["PO_RUN_SINGLE_TASK"];
+
+  if (opts.startFromTask) {
+    env["PO_START_FROM_TASK"] = opts.startFromTask;
+  }
+  if (opts.runSingleTask) {
+    env["PO_RUN_SINGLE_TASK"] = "true";
+  }
+
+  return env;
+}
+
+async function spawnRunner(
+  dataDir: string,
+  jobId: string,
+  jobDir: string,
+  opts: { startFromTask?: string; runSingleTask?: boolean } = {},
+): Promise<void> {
   const proc = Bun.spawn({
-    cmd: args,
+    cmd: ["bun", "run", RUNNER_PATH, jobId],
     stdout: "ignore",
     stderr: "ignore",
     stdin: "ignore",
-    env: env ?? process.env as Record<string, string>,
+    env: buildRunnerEnv(dataDir, opts),
     detached: true,
   });
+  await Bun.write(path.join(jobDir, "runner.pid"), `${proc.pid}\n`);
   proc.unref();
 }
 
@@ -73,6 +102,10 @@ function isNonTerminalTaskState(state: unknown): boolean {
   return state === "pending" || state === "running";
 }
 
+function isDependencySatisfied(state: unknown): boolean {
+  return state === "done";
+}
+
 function isTaskLikelyInProgress(task: Record<string, unknown>): boolean {
   const state = task["state"];
   const nonTerminal = isNonTerminalTaskState(state);
@@ -88,6 +121,40 @@ function getProgressPercent(snapshot: StatusSnapshot): number {
   if (tasks.length === 0) return 0;
   const doneCount = tasks.filter((task) => task.state === "done").length;
   return Math.floor((doneCount / tasks.length) * 100);
+}
+
+function getTaskName(task: unknown): string | null {
+  if (typeof task === "string" && task.length > 0) return task;
+  if (typeof task !== "object" || task === null || Array.isArray(task)) return null;
+  const name = (task as Record<string, unknown>)["name"];
+  return typeof name === "string" && name.length > 0 ? name : null;
+}
+
+async function readSeedPipelineSlug(jobDir: string): Promise<string | null> {
+  try {
+    const seed = JSON.parse(await Bun.file(path.join(jobDir, "seed.json")).text()) as Record<string, unknown>;
+    return typeof seed["pipeline"] === "string" && seed["pipeline"].length > 0 ? seed["pipeline"] : null;
+  } catch {
+    return null;
+  }
+}
+
+async function loadPipelineTaskOrder(dataDir: string, jobDir: string, snapshot: StatusSnapshot): Promise<string[] | null> {
+  const snapshotPipeline = snapshot["pipeline"];
+  const pipelineSlug = typeof snapshotPipeline === "string" && snapshotPipeline.length > 0
+    ? snapshotPipeline
+    : await readSeedPipelineSlug(jobDir);
+
+  if (!pipelineSlug) return null;
+
+  try {
+    const { pipelineJsonPath } = getPipelineConfig(pipelineSlug, dataDir);
+    const pipeline = JSON.parse(await Bun.file(pipelineJsonPath).text()) as Record<string, unknown>;
+    if (!Array.isArray(pipeline["tasks"])) return null;
+    return pipeline["tasks"].map(getTaskName).filter((name): name is string => name !== null);
+  } catch {
+    return null;
+  }
 }
 
 function findRecoveryTask(snapshot: StatusSnapshot): string | null {
@@ -252,8 +319,9 @@ export async function handleJobRestart(
 
     const status = await readJobStatus(jobDir);
     if (status) {
-      const taskEntries = Object.values(status.tasks).filter((t): t is typeof t & { state: unknown } => "state" in t);
-      const derivedStatus = deriveJobStatusFromTasks(taskEntries);
+      const derivedStatus = deriveJobStatusFromTasks(
+        Object.values(status.tasks).map((task) => ({ state: task.state })),
+      );
       if (derivedStatus === "running") {
         return sendJson(409, createErrorResponse("job_running", "Job is currently running (task-level running)"));
       }
@@ -277,20 +345,10 @@ export async function handleJobRestart(
       mode = "clean-slate";
     }
 
-    // Build environment for the pipeline runner
-    const env: Record<string, string | undefined> = {
-      ...process.env as Record<string, string>,
-      PO_ROOT: dataDir,
-    };
-    if (fromTask) {
-      env["PO_START_FROM_TASK"] = fromTask;
-    }
-    if (singleTask && !continueAfter) {
-      env["PO_RUN_SINGLE_TASK"] = "true";
-    }
-
-    // Spawn the pipeline runner as a detached process
-    await spawnDetached(["bun", "run", RUNNER_PATH, jobId], env);
+    await spawnRunner(dataDir, jobId, jobDir, {
+      startFromTask: fromTask,
+      runSingleTask: Boolean(singleTask && !continueAfter),
+    });
 
     return sendJson(202, { ok: true, jobId, mode, spawned: true });
   } finally {
@@ -426,15 +484,18 @@ export async function handleTaskStart(
     }
 
     const snapshot = await readJobStatus(jobDir);
-    if (snapshot) {
-      const taskEntries = Object.values(snapshot.tasks).filter((t): t is typeof t & { state: unknown } => "state" in t);
-      const derivedStatus = deriveJobStatusFromTasks(taskEntries);
-      if (derivedStatus === "running") {
-        return sendJson(409, createErrorResponse("job_running", "Job is currently running (task-level running)"));
-      }
+    if (!snapshot) {
+      return sendJson(500, createErrorResponse("status_unavailable", `job "${jobId}" status could not be read`));
     }
 
-    const targetTask = snapshot?.tasks[taskId];
+    const derivedStatus = deriveJobStatusFromTasks(
+      Object.values(snapshot.tasks).map((task) => ({ state: task.state })),
+    );
+    if (derivedStatus === "running") {
+      return sendJson(409, createErrorResponse("job_running", "Job is currently running (task-level running)"));
+    }
+
+    const targetTask = snapshot.tasks[taskId];
     if (!targetTask) {
       return sendJson(404, createErrorResponse("task_not_found", `task "${taskId}" was not found`));
     }
@@ -443,19 +504,23 @@ export async function handleTaskStart(
       return sendJson(422, createErrorResponse("task_not_pending", `task "${taskId}" is not pending`));
     }
 
-    for (const priorTaskId of Object.keys(snapshot!.tasks)) {
-      if (priorTaskId === taskId) break;
-      if (snapshot!.tasks[priorTaskId]!.state !== "done") {
+    const pipelineTaskOrder = await loadPipelineTaskOrder(dataDir, jobDir, snapshot);
+    if (!pipelineTaskOrder) {
+      return sendJson(500, createErrorResponse("status_unavailable", `pipeline task order for job "${jobId}" could not be read`));
+    }
+
+    const taskIndex = pipelineTaskOrder.indexOf(taskId);
+    if (taskIndex === -1) {
+      return sendJson(404, createErrorResponse("task_not_found", `task "${taskId}" was not found in the pipeline definition`));
+    }
+
+    for (const priorTaskId of pipelineTaskOrder.slice(0, taskIndex)) {
+      if (!isDependencySatisfied(snapshot.tasks[priorTaskId]?.state)) {
         return sendJson(412, createErrorResponse("dependencies_not_satisfied", `task "${priorTaskId}" must be done before "${taskId}"`));
       }
     }
 
-    const env: Record<string, string | undefined> = {
-      ...(process.env as Record<string, string>),
-      PO_ROOT: dataDir,
-      PO_START_FROM_TASK: taskId,
-    };
-    await spawnDetached(["bun", "run", RUNNER_PATH, jobId], env);
+    await spawnRunner(dataDir, jobId, jobDir, { startFromTask: taskId });
 
     return sendJson(202, {
       ok: true,

--- a/src/ui/server/endpoints/job-control-endpoints.ts
+++ b/src/ui/server/endpoints/job-control-endpoints.ts
@@ -414,6 +414,42 @@ export async function handleTaskStart(
       return sendJson(404, createErrorResponse(Constants.ERROR_CODES.JOB_NOT_FOUND, `job "${jobId}" was not found`));
     }
 
+    if (lifecycle !== "current") {
+      return sendJson(409, createErrorResponse("unsupported_lifecycle", `job "${jobId}" is not in the current lifecycle`));
+    }
+
+    const jobDir = getJobDirectoryPath(dataDir, jobId, "current");
+
+    const pid = await readRunnerPid(jobDir);
+    if (pid !== null && isProcessAlive(pid)) {
+      return sendJson(409, createErrorResponse("job_running", "Job is currently running (process alive)"));
+    }
+
+    const snapshot = await readJobStatus(jobDir);
+    if (snapshot) {
+      const taskEntries = Object.values(snapshot.tasks).filter((t): t is typeof t & { state: unknown } => "state" in t);
+      const derivedStatus = deriveJobStatusFromTasks(taskEntries);
+      if (derivedStatus === "running") {
+        return sendJson(409, createErrorResponse("job_running", "Job is currently running (task-level running)"));
+      }
+    }
+
+    const targetTask = snapshot?.tasks[taskId];
+    if (!targetTask) {
+      return sendJson(404, createErrorResponse("task_not_found", `task "${taskId}" was not found`));
+    }
+
+    if (targetTask.state !== "pending") {
+      return sendJson(422, createErrorResponse("task_not_pending", `task "${taskId}" is not pending`));
+    }
+
+    for (const priorTaskId of Object.keys(snapshot!.tasks)) {
+      if (priorTaskId === taskId) break;
+      if (snapshot!.tasks[priorTaskId]!.state !== "done") {
+        return sendJson(412, createErrorResponse("dependencies_not_satisfied", `task "${priorTaskId}" must be done before "${taskId}"`));
+      }
+    }
+
     await mkdir(path.join(dataDir, "pipeline-data"), { recursive: true });
     await spawnDetached(["bun", "-e", "process.exit(0)"]);
     return sendJson(202, { ok: true, jobId, taskId, action: "start", lifecycle });


### PR DESCRIPTION
Closes #282

## Summary

- `handleTaskStart` now validates job lifecycle, runner liveness, target task state, and upstream dependencies at the API boundary, returning the error codes the existing UI already handles (`unsupported_lifecycle`, `job_running`, `task_not_found`, `task_not_pending`, `dependencies_not_satisfied`).
- The no-op stub spawn (`bun -e "process.exit(0)"`) is replaced with the real `bun run pipeline-runner.ts <jobId>` invocation, with `PO_ROOT` and `PO_START_FROM_TASK` set so the runner resumes from the requested task without resetting upstream `done` work.
- Success response is locked to `{ ok: true, jobId, taskId, action: "start", lifecycle: "current", spawned: true }`.

Validation runs at the endpoint because `runPipelineJob` intentionally bypasses lifecycle checks when `PO_START_FROM_TASK` is set; pushing the checks into the runner would change restart semantics. See the issue for the full trade-off discussion.

## Test plan

- [x] `bun test src/ui/server/__tests__/job-control-endpoints.test.ts` — 22 pass, 0 fail (15 existing restart/stop tests untouched, 8 new task-start tests covering all error branches and the success path).
- [ ] Manual smoke: in a real `current/` job with a `done` upstream task and a `pending` next task, click Start in `DAGGrid` and confirm the pipeline resumes through the remaining tasks.