### PR TITLE
fix: stop task-runner from writing pipeline-owned lifecycle fields, increase default timeout to 1 hour

### DIFF
--- a/src/core/__tests__/task-runner.test.ts
+++ b/src/core/__tests__/task-runner.test.ts
@@ -60,7 +60,7 @@ describe("runPipeline log tracking", () => {
 });
 
 describe("task-runner does not write job-level status fields", () => {
-  it("does not set snapshot.state, snapshot.current, snapshot.currentStage, or snapshot.progress on success", async () => {
+  it("does not set snapshot.state, snapshot.current, or snapshot.currentStage on success", async () => {
     const root = await makeTempRoot();
     const workDir = path.join(root, "job-1");
     await mkdir(workDir, { recursive: true });
@@ -91,11 +91,10 @@ describe("task-runner does not write job-level status fields", () => {
 
     const status = JSON.parse(await readFile(path.join(workDir, "tasks-status.json"), "utf8")) as StatusSnapshot;
 
-    // Job-level fields must remain untouched by task-runner
+    // Lifecycle fields are owned by pipeline-runner; task-runner persists progress only.
     expect(status.state).toBe("pending");
     expect(status.current).toBeNull();
     expect(status.currentStage).toBeNull();
-    expect(status.progress).toBeUndefined();
   });
 
   it("does not set snapshot.state on task failure", async () => {

--- a/src/core/task-runner.ts
+++ b/src/core/task-runner.ts
@@ -4,7 +4,7 @@
 import { mkdir } from "node:fs/promises";
 import { dirname, isAbsolute, join } from "node:path";
 import { pathToFileURL } from "node:url";
-import { KNOWN_STAGES } from "./progress";
+import { KNOWN_STAGES, computeDeterministicProgress } from "./progress";
 import type { StageName } from "./progress";
 import { createTaskFileIO, generateLogName, trackFile } from "./file-io";
 import type { TaskFileIO } from "./file-io";
@@ -802,10 +802,7 @@ export async function runPipeline(
       lastStage,
     );
     await writeJobStatus(jobDir, (snapshot: StatusSnapshot) => {
-      snapshot.state = TaskState.DONE;
       snapshot.progress = doneProgress;
-      snapshot.current = null;
-      snapshot.currentStage = null;
       if (!snapshot.tasks[taskName]) snapshot.tasks[taskName] = {};
       snapshot.tasks[taskName]!.state = TaskState.DONE;
       snapshot.tasks[taskName]!.currentStage = null;

--- a/src/providers/__tests__/base.test.ts
+++ b/src/providers/__tests__/base.test.ts
@@ -165,8 +165,8 @@ describe("isRetryableError", () => {
 });
 
 describe("DEFAULT_REQUEST_TIMEOUT_MS", () => {
-  it("is 120 000 ms", () => {
-    expect(DEFAULT_REQUEST_TIMEOUT_MS).toBe(120_000);
+  it("is 1 hour (3 600 000 ms)", () => {
+    expect(DEFAULT_REQUEST_TIMEOUT_MS).toBe(3_600_000);
   });
 });
 

--- a/src/providers/__tests__/openai.test.ts
+++ b/src/providers/__tests__/openai.test.ts
@@ -352,7 +352,7 @@ describe("openaiChat", () => {
       organization: "org_test",
       baseURL: "https://example.test/v1",
       maxRetries: 0,
-      timeout: 120_000,
+      timeout: 3_600_000,
     });
   });
 


### PR DESCRIPTION
## Summary

Two fixes on `rpm-fix-test`:

- **Task-runner ownership boundary**: `runPipeline` no longer writes `state`, `current`, or `currentStage` — those lifecycle fields are owned by `pipeline-runner`. The task-runner now only persists `progress` on completion.
- **Default timeout**: `DEFAULT_REQUEST_TIMEOUT_MS` increased from 120s to 3,600,000 ms (1 hour) to match the intended behavior for long-running LLM requests. Updated test assertions accordingly.