### PR TITLE
Add global task retry limit and DAG restart badge

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -10,7 +10,8 @@
   "taskRunner": {
     "maxRefinementAttempts": 2,
     "stageTimeout": 300000,
-    "llmRequestTimeout": 60000
+    "llmRequestTimeout": 60000,
+    "maxAttempts": 3
   },
   "llm": {
     "defaultProvider": "deepseek",

--- a/config.schema.json
+++ b/config.schema.json
@@ -67,6 +67,12 @@
           "description": "Timeout in milliseconds for LLM requests",
           "minimum": 1000,
           "default": 60000
+        },
+        "maxAttempts": {
+          "type": "integer",
+          "description": "Maximum total attempts for a failing task (1 = no retry).",
+          "minimum": 1,
+          "default": 3
         }
       }
     },

--- a/src/core/__tests__/config.test.ts
+++ b/src/core/__tests__/config.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect, afterEach } from "bun:test";
 import { defaultConfig, resetConfig, loadConfig, getConfig, getConfigValue, getPipelineConfig } from "../config";
+import type { AppConfig } from "../config";
 import { mkdtemp, writeFile, mkdir, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -70,6 +71,51 @@ describe("defaultConfig", () => {
     expect(defaultConfig.llm.defaultProvider).toBe("openai");
     expect(defaultConfig.ui.port).toBe(3000);
     expect(defaultConfig.taskRunner.maxRefinementAttempts).toBeGreaterThan(0);
+  });
+
+  test("taskRunner.maxAttempts defaults to 3", () => {
+    expect(defaultConfig.taskRunner.maxAttempts).toBe(3);
+  });
+});
+
+describe("validateConfig (via loadConfig)", () => {
+  afterEach(() => {
+    resetConfig();
+  });
+
+  test("throws when taskRunner.maxAttempts is 0", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "config-test-"));
+    const configDir = join(dir, "pipeline-config", "test");
+    const tasksDir = join(configDir, "tasks");
+    await mkdir(tasksDir, { recursive: true });
+    await writeFile(join(configDir, "pipeline.json"), JSON.stringify({ name: "test", tasks: ["t1"] }));
+    await writeFile(join(dir, "pipeline-config", "registry.json"), JSON.stringify({
+      pipelines: { test: { configDir, tasksDir } }
+    }));
+    const overrideFile = join(dir, "config.json");
+    await writeFile(overrideFile, JSON.stringify({ taskRunner: { maxAttempts: 0 } }));
+    const origRoot = process.env.PO_ROOT;
+    process.env.PO_ROOT = dir;
+    try {
+      await expect(loadConfig({ configPath: overrideFile })).rejects.toThrow("taskRunner.maxAttempts must be >= 1");
+    } finally {
+      if (origRoot) process.env.PO_ROOT = origRoot; else delete process.env.PO_ROOT;
+      await rm(dir, { recursive: true });
+    }
+  });
+});
+
+describe("PO_TASK_MAX_ATTEMPTS env override", () => {
+  afterEach(() => {
+    delete process.env.PO_TASK_MAX_ATTEMPTS;
+    resetConfig();
+  });
+
+  test("getConfig reads PO_TASK_MAX_ATTEMPTS into taskRunner.maxAttempts", () => {
+    process.env.PO_TASK_MAX_ATTEMPTS = "5";
+    resetConfig();
+    const config: AppConfig = getConfig();
+    expect(config.taskRunner.maxAttempts).toBe(5);
   });
 });
 

--- a/src/core/__tests__/pipeline-runner.test.ts
+++ b/src/core/__tests__/pipeline-runner.test.ts
@@ -9,12 +9,14 @@ import { join } from "node:path";
 // deterministic no-ops; config/validation/module-loader are replaced so we
 // don't need a real pipelines directory on disk.
 
+const mockGetConfig = mock(() => ({ taskRunner: { maxAttempts: 3 } }));
+
 mock.module("../config", () => ({
   getPipelineConfig: mock((_slug: string) => ({
     pipelineJsonPath: "/mock/pipeline.json",
     tasksDir: "/mock/tasks",
   })),
-  getConfig: mock(() => ({})),
+  getConfig: mockGetConfig,
   loadConfig: mock(async () => ({})),
   resetConfig: mock(() => {}),
 }));
@@ -95,6 +97,7 @@ const PO_ENV_KEYS = [
   "PO_TASK_REGISTRY",
   "PO_START_FROM_TASK",
   "PO_RUN_SINGLE_TASK",
+  "PO_TASK_MAX_ATTEMPTS",
 ] as const;
 
 interface MultiTaskFixture {
@@ -357,5 +360,221 @@ describe("runPipelineJob — outer-catch failure surfacing", () => {
       args.some((a) => typeof a === "string" && a.includes(injectedMessage)),
     );
     expect(stderrContainsMessage).toBe(true);
+  });
+});
+
+describe("runPipelineJob — bounded retry loop", () => {
+  const savedEnv: Record<string, string | undefined> = {};
+  const cleanupDirs: string[] = [];
+  let originalSleep: typeof Bun.sleep;
+  let sleepDelays: number[];
+
+  beforeEach(() => {
+    for (const key of Object.keys(savedEnv)) delete savedEnv[key];
+    for (const key of PO_ENV_KEYS) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+
+    mockRunPipeline.mockClear();
+    mockEnsureTaskSymlinkBridge.mockClear();
+    mockValidateTaskSymlinks.mockClear();
+    mockRepairTaskSymlinks.mockClear();
+    mockCleanupTaskSymlinks.mockClear();
+    mockLoadFreshModule.mockClear();
+    mockGetConfig.mockReset();
+    mockGetConfig.mockImplementation(() => ({ taskRunner: { maxAttempts: 3 } }));
+
+    sleepDelays = [];
+    originalSleep = Bun.sleep;
+    (Bun as unknown as { sleep: (ms: number) => Promise<void> }).sleep = async (ms: number) => {
+      sleepDelays.push(ms);
+    };
+  });
+
+  afterEach(async () => {
+    (Bun as unknown as { sleep: typeof Bun.sleep }).sleep = originalSleep;
+
+    for (const key of PO_ENV_KEYS) {
+      if (savedEnv[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = savedEnv[key];
+      }
+    }
+    process.exitCode = 0;
+
+    await Promise.all(cleanupDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  });
+
+  function makeFailureResult() {
+    return {
+      ok: false as const,
+      failedStage: "generate",
+      error: {
+        name: "TaskFailure",
+        message: "stub failure",
+        stack: "stack",
+        debug: { stage: "generate", logPath: "/tmp/log" },
+      },
+      logs: [{ stage: "generate", ok: false as const, ms: 5, error: "stub" }],
+      context: {} as Record<string, unknown>,
+    };
+  }
+
+  function makeSuccessResult() {
+    return {
+      ok: true as const,
+      logs: [{ stage: "generate", ok: true as const, ms: 5 }],
+      context: {} as Record<string, unknown>,
+      llmMetrics: [],
+    };
+  }
+
+  test("maxAttempts: 1 — failing task runs once and exits non-zero", async () => {
+    mockGetConfig.mockImplementation(() => ({ taskRunner: { maxAttempts: 1 } }));
+    const fixture = await setupMultiTaskFixture(["task-a"]);
+    cleanupDirs.push(fixture.tmpDir);
+
+    mockRunPipeline.mockImplementation(async () => makeFailureResult() as never);
+
+    const exitCalls: Array<number | undefined> = [];
+    const exitSpy = spyOn(process, "exit").mockImplementation(((code?: number) => {
+      exitCalls.push(code);
+      throw new Error(`__test_exit__:${String(code)}`);
+    }) as typeof process.exit);
+
+    try {
+      await runPipelineJob(fixture.jobId);
+    } catch (e) {
+      if (!(e instanceof Error) || !/^__test_exit__:/.test(e.message)) throw e;
+    } finally {
+      exitSpy.mockRestore();
+    }
+
+    expect(mockRunPipeline.mock.calls.length).toBe(1);
+    expect(sleepDelays).toEqual([]);
+    expect(exitCalls).toContain(1);
+
+    const statusText = await readFile(join(fixture.jobDir, "tasks-status.json"), "utf-8");
+    const status = JSON.parse(statusText) as {
+      tasks: Record<string, { state?: string; restartCount?: number }>;
+    };
+    expect(status.tasks["task-a"]?.state).toBe("failed");
+    const rc = status.tasks["task-a"]?.restartCount;
+    expect(rc === undefined || rc === 0).toBe(true);
+  });
+
+  test("maxAttempts: 3 — fails twice then succeeds: three calls, restartCount=2, exits zero", async () => {
+    mockGetConfig.mockImplementation(() => ({ taskRunner: { maxAttempts: 3 } }));
+    const fixture = await setupMultiTaskFixture(["task-a"]);
+    cleanupDirs.push(fixture.tmpDir);
+
+    let call = 0;
+    mockRunPipeline.mockImplementation(async () => {
+      call += 1;
+      return (call <= 2 ? makeFailureResult() : makeSuccessResult()) as never;
+    });
+
+    const exitCalls: Array<number | undefined> = [];
+    const exitSpy = spyOn(process, "exit").mockImplementation(((code?: number) => {
+      exitCalls.push(code);
+      throw new Error(`__test_exit__:${String(code)}`);
+    }) as typeof process.exit);
+
+    try {
+      await runPipelineJob(fixture.jobId);
+    } catch (e) {
+      if (!(e instanceof Error) || !/^__test_exit__:/.test(e.message)) throw e;
+    } finally {
+      exitSpy.mockRestore();
+    }
+
+    expect(mockRunPipeline.mock.calls.length).toBe(3);
+    expect(sleepDelays).toEqual([2000, 4000]);
+    expect(exitCalls).toEqual([]);
+
+    const statusText = await readFile(fixture.statusPath, "utf-8");
+    const status = JSON.parse(statusText) as {
+      tasks: Record<string, { state?: string; restartCount?: number }>;
+    };
+    expect(status.tasks["task-a"]?.state).toBe("done");
+    expect(status.tasks["task-a"]?.restartCount).toBe(2);
+  });
+
+  test("maxAttempts: 3 — always fails: three calls, restartCount=2, exits non-zero", async () => {
+    mockGetConfig.mockImplementation(() => ({ taskRunner: { maxAttempts: 3 } }));
+    const fixture = await setupMultiTaskFixture(["task-a"]);
+    cleanupDirs.push(fixture.tmpDir);
+
+    mockRunPipeline.mockImplementation(async () => makeFailureResult() as never);
+
+    const exitCalls: Array<number | undefined> = [];
+    const exitSpy = spyOn(process, "exit").mockImplementation(((code?: number) => {
+      exitCalls.push(code);
+      throw new Error(`__test_exit__:${String(code)}`);
+    }) as typeof process.exit);
+
+    try {
+      await runPipelineJob(fixture.jobId);
+    } catch (e) {
+      if (!(e instanceof Error) || !/^__test_exit__:/.test(e.message)) throw e;
+    } finally {
+      exitSpy.mockRestore();
+    }
+
+    expect(mockRunPipeline.mock.calls.length).toBe(3);
+    expect(sleepDelays).toEqual([2000, 4000]);
+    expect(exitCalls).toContain(1);
+
+    const statusText = await readFile(join(fixture.jobDir, "tasks-status.json"), "utf-8");
+    const status = JSON.parse(statusText) as {
+      tasks: Record<string, { state?: string; restartCount?: number }>;
+    };
+    expect(status.tasks["task-a"]?.state).toBe("failed");
+    expect(status.tasks["task-a"]?.restartCount).toBe(2);
+  });
+
+  test("interim status between attempts: state=running, no failedStage/error, restartCount incremented", async () => {
+    mockGetConfig.mockImplementation(() => ({ taskRunner: { maxAttempts: 3 } }));
+    const fixture = await setupMultiTaskFixture(["task-a"]);
+    cleanupDirs.push(fixture.tmpDir);
+
+    let call = 0;
+    let interimSnapshot: { state?: string; failedStage?: unknown; error?: unknown; restartCount?: number } | undefined;
+
+    // Capture the snapshot from disk *during* the second call (after the first failure
+    // and the interim writeJobStatus). At call #2 we read tasks-status.json, then
+    // return success so the test ends cleanly.
+    mockRunPipeline.mockImplementation(async () => {
+      call += 1;
+      if (call === 2) {
+        const text = await readFile(join(fixture.jobDir, "tasks-status.json"), "utf-8");
+        const parsed = JSON.parse(text) as {
+          tasks: Record<string, { state?: string; failedStage?: unknown; error?: unknown; restartCount?: number }>;
+        };
+        interimSnapshot = parsed.tasks["task-a"];
+        return makeSuccessResult() as never;
+      }
+      return makeFailureResult() as never;
+    });
+
+    const exitSpy = spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`__test_exit__:${String(code)}`);
+    }) as typeof process.exit);
+
+    try {
+      await runPipelineJob(fixture.jobId);
+    } catch (e) {
+      if (!(e instanceof Error) || !/^__test_exit__:/.test(e.message)) throw e;
+    } finally {
+      exitSpy.mockRestore();
+    }
+
+    expect(interimSnapshot).toBeDefined();
+    expect(interimSnapshot?.state).toBe("running");
+    expect(interimSnapshot?.failedStage).toBeUndefined();
+    expect(interimSnapshot?.error).toBeUndefined();
+    expect(interimSnapshot?.restartCount).toBe(1);
   });
 });

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -16,6 +16,7 @@ export interface TaskRunnerConfig {
   maxRefinementAttempts: number;
   stageTimeout: number;
   llmRequestTimeout: number;
+  maxAttempts: number;
 }
 
 export interface LLMConfig {
@@ -95,6 +96,7 @@ export const defaultConfig = {
     maxRefinementAttempts: 3,
     stageTimeout: 300000,
     llmRequestTimeout: 3600000,
+    maxAttempts: 3,
   },
   llm: {
     defaultProvider: "openai",
@@ -184,6 +186,11 @@ function loadFromEnvironment(config: AppConfig): AppConfig {
     overrides["llm"] = { maxConcurrency: parseInt(maxConcurrencyRaw, 10) };
   }
 
+  const maxAttemptsRaw = process.env["PO_TASK_MAX_ATTEMPTS"];
+  if (maxAttemptsRaw) {
+    overrides["taskRunner"] = { maxAttempts: parseInt(maxAttemptsRaw, 10) };
+  }
+
   const shutdownTimeoutRaw = process.env["PO_SHUTDOWN_TIMEOUT"];
   if (shutdownTimeoutRaw) {
     overrides["orchestrator"] = { shutdownTimeout: parseInt(shutdownTimeoutRaw, 10) };
@@ -226,6 +233,9 @@ function validateConfig(config: AppConfig): void {
   }
   if (config.taskRunner.maxRefinementAttempts < 1) {
     errors.push(`taskRunner.maxRefinementAttempts must be >= 1, got ${config.taskRunner.maxRefinementAttempts}`);
+  }
+  if (config.taskRunner.maxAttempts < 1) {
+    errors.push(`taskRunner.maxAttempts must be >= 1, got ${config.taskRunner.maxAttempts}`);
   }
   if (!(VALID_LOG_LEVELS as readonly string[]).includes(config.logging.level)) {
     errors.push(`logging.level must be one of ${VALID_LOG_LEVELS.join(", ")}, got ${config.logging.level}`);

--- a/src/core/pipeline-runner.ts
+++ b/src/core/pipeline-runner.ts
@@ -2,13 +2,13 @@ import { join, dirname, resolve, basename } from "node:path";
 import { pathToFileURL } from "node:url";
 import { unlink, mkdir, rename, appendFile } from "node:fs/promises";
 import { unlinkSync } from "node:fs";
-import { getPipelineConfig } from "./config";
+import { getConfig, getPipelineConfig } from "./config";
 import { validatePipelineOrThrow } from "./validation";
 import { loadFreshModule } from "./module-loader";
 import { writeJobStatus } from "./status-writer";
 import { decideTransition } from "./lifecycle-policy";
 import { runPipeline } from "./task-runner";
-import type { AuditLogEntry } from "./task-runner";
+import type { AuditLogEntry, PipelineResult } from "./task-runner";
 import { ensureTaskSymlinkBridge } from "./symlink-bridge";
 import { validateTaskSymlinks, repairTaskSymlinks, cleanupTaskSymlinks } from "./symlink-utils";
 import { createTaskFileIO, generateLogName } from "./file-io";
@@ -257,6 +257,10 @@ export async function loadTaskRegistry(registryPath: string): Promise<TaskRegist
 
 // ─── Pipeline job entry point ─────────────────────────────────────────────────
 
+const INITIAL_RETRY_DELAY_MS = 2_000;
+const MAX_RETRY_DELAY_MS = 30_000;
+const RETRY_BACKOFF_MULTIPLIER = 2;
+
 /** Runs a pipeline job end-to-end for the given job ID. */
 export async function runPipelineJob(jobId: string): Promise<void> {
   let workDir: string | undefined;
@@ -415,8 +419,37 @@ export async function runPipelineJob(jobId: string): Promise<void> {
       },
     };
 
-    // Delegate to task runner
-    const result = await runPipeline(relocatedEntryPath, taskExecutionContext);
+    // Delegate to task runner with bounded retry loop.
+    // Guard against test mocks that may return a non-integer maxAttempts.
+    const configuredMaxAttempts = getConfig().taskRunner.maxAttempts;
+    const maxAttempts = Number.isInteger(configuredMaxAttempts) ? configuredMaxAttempts : 3;
+    const cap = Math.max(1, maxAttempts);
+
+    let result: PipelineResult | undefined;
+    for (let attempt = 1; attempt <= cap; attempt++) {
+      result = await runPipeline(relocatedEntryPath, taskExecutionContext);
+      if (result.ok) break;
+      if (attempt >= cap) break;
+
+      const delay = Math.min(
+        INITIAL_RETRY_DELAY_MS * RETRY_BACKOFF_MULTIPLIER ** (attempt - 1),
+        MAX_RETRY_DELAY_MS,
+      );
+
+      await writeJobStatus(config.workDir, (snapshot) => {
+        const entry = (snapshot.tasks[taskName] ?? {}) as Record<string, unknown>;
+        entry["state"] = "running";
+        entry["attempts"] = ((entry["attempts"] as number | undefined) ?? 1) + 1;
+        entry["restartCount"] = ((entry["restartCount"] as number | undefined) ?? 0) + 1;
+        delete entry["failedStage"];
+        delete entry["error"];
+        snapshot.tasks[taskName] = entry as typeof snapshot.tasks[string];
+      });
+
+      await Bun.sleep(delay);
+    }
+
+    if (!result) throw new Error("Retry loop produced no result");
 
     if (result.ok) {
       // Compute execution time from logs

--- a/src/core/pipeline-runner.ts
+++ b/src/core/pipeline-runner.ts
@@ -98,6 +98,7 @@ export interface TaskStatus {
   attempts?: number;
   executionTimeMs?: number;
   refinementAttempts?: number;
+  restartCount?: number;
   error?: NormalizedError;
   failedStage?: string;
   stageLogPath?: string;

--- a/src/core/status-writer.ts
+++ b/src/core/status-writer.ts
@@ -14,6 +14,7 @@ export interface TaskEntry {
   failedStage?: string;
   error?: string;
   attempts?: number;
+  restartCount?: number;
   refinementAttempts?: number;
   tokenUsage?: unknown[];
   startedAt?: string;
@@ -227,6 +228,7 @@ export function resetJobFromTask(jobDir: string, fromTask: string, options?: Res
       delete task.failedStage;
       delete task.error;
       task.attempts = 0;
+      task.restartCount = 0;
       task.refinementAttempts = 0;
       if (options?.clearTokenUsage !== false) {
         task.tokenUsage = [];
@@ -253,6 +255,7 @@ export function resetJobToCleanSlate(jobDir: string, options?: ResetOptions): Pr
       delete task.failedStage;
       delete task.error;
       task.attempts = 0;
+      task.restartCount = 0;
       task.refinementAttempts = 0;
       if (options?.clearTokenUsage !== false) {
         task.tokenUsage = [];
@@ -280,6 +283,7 @@ export function resetSingleTask(jobDir: string, taskId: string, options?: ResetO
     delete task.failedStage;
     delete task.error;
     task.attempts = 0;
+    task.restartCount = 0;
     task.refinementAttempts = 0;
     if (options?.clearTokenUsage !== false) {
       task.tokenUsage = [];

--- a/src/ui/client/__tests__/job-adapter.test.ts
+++ b/src/ui/client/__tests__/job-adapter.test.ts
@@ -30,6 +30,18 @@ describe("job adapter", () => {
     expect(normalizeTasks(null)).toEqual({});
   });
 
+  it("maps numeric restartCount onto the normalized task", () => {
+    expect(normalizeTasks({ t1: { state: "done", restartCount: 2 } })["t1"]?.restartCount).toBe(2);
+  });
+
+  it("treats null restartCount as undefined", () => {
+    expect(normalizeTasks({ t1: { state: "done", restartCount: null } })["t1"]?.restartCount).toBeUndefined();
+  });
+
+  it("leaves restartCount undefined when absent", () => {
+    expect(normalizeTasks({ t1: { state: "done" } })["t1"]?.restartCount).toBeUndefined();
+  });
+
   it("adapts summary jobs with defaults", () => {
     const job = adaptJobSummary({
       jobId: "job-1",

--- a/src/ui/client/adapters/job-adapter.ts
+++ b/src/ui/client/adapters/job-adapter.ts
@@ -49,6 +49,7 @@ function normalizeTask(name: string, rawTask: unknown): NormalizedTask {
     startedAt: toStringOrNull(task["startedAt"]),
     endedAt: toStringOrNull(task["endedAt"]),
     attempts: typeof task["attempts"] === "number" ? task["attempts"] : undefined,
+    restartCount: typeof task["restartCount"] === "number" ? task["restartCount"] : undefined,
     executionTimeMs: typeof task["executionTimeMs"] === "number" ? task["executionTimeMs"] : undefined,
     currentStage: typeof task["currentStage"] === "string" ? task["currentStage"] : undefined,
     failedStage: typeof task["failedStage"] === "string" ? task["failedStage"] : undefined,

--- a/src/ui/client/types.ts
+++ b/src/ui/client/types.ts
@@ -89,6 +89,7 @@ export interface NormalizedTask {
   startedAt: string | null;
   endedAt: string | null;
   attempts?: number;
+  restartCount?: number;
   executionTimeMs?: number;
   currentStage?: string;
   failedStage?: string;

--- a/src/ui/components/DAGGrid.tsx
+++ b/src/ui/components/DAGGrid.tsx
@@ -276,6 +276,16 @@ export default function DAGGrid({
                 data-role="card-header"
                 className={`flex items-center justify-between gap-3 rounded-t-lg border-b px-4 py-2 ${reducedMotion ? "" : "transition-opacity duration-300 ease-in-out"} ${getHeaderClasses(getItemStatus(items[index], index, activeIndex))}`}
               >
+                {(items[index]?.restartCount ?? 0) > 0 ? (
+                  <span
+                    data-role="restart-badge"
+                    className="inline-flex items-center justify-center min-w-[20px] h-5 px-1.5 rounded-sm border border-red-300 bg-red-50 text-red-700 text-[11px] font-medium tabular-nums"
+                    title={`Restarted ${items[index]!.restartCount} time${items[index]!.restartCount === 1 ? "" : "s"}`}
+                    aria-label={`Restarted ${items[index]!.restartCount} time${items[index]!.restartCount === 1 ? "" : "s"}`}
+                  >
+                    ↻ {items[index]!.restartCount}
+                  </span>
+                ) : null}
                 <div className="truncate font-medium">{items[index]?.title ?? formatStepName(items[index]?.id ?? "")}</div>
                 <div className="flex items-center gap-2">
                   {getItemStatus(items[index], index, activeIndex) === "running" ? (

--- a/src/ui/components/JobDetail.tsx
+++ b/src/ui/components/JobDetail.tsx
@@ -43,7 +43,8 @@ export default function JobDetail({
         prior.stage === item.stage &&
         prior.title === item.title &&
         prior.subtitle === item.subtitle &&
-        prior.body === item.body
+        prior.body === item.body &&
+        prior.restartCount === item.restartCount
       ) {
         return prior;
       }

--- a/src/ui/components/__tests__/DAGGrid.test.tsx
+++ b/src/ui/components/__tests__/DAGGrid.test.tsx
@@ -117,3 +117,95 @@ test("DAGGrid opens task details from keyboard interaction and renders connector
   expect(view.getByText("Build · done")).toBeTruthy();
   expect(view.container.querySelectorAll('path[marker-end="url(#dag-grid-arrow)"]').length).toBe(1);
 });
+
+test("DAGGrid does not render the restart badge when restartCount is absent or zero", () => {
+  installMatchMedia();
+
+  const view = render(
+    <DAGGrid
+      items={[makeItem({ id: "build", title: "Build", status: "pending" })]}
+      jobId="job-1"
+      taskById={{ build: makeTaskState({ name: "build", state: "pending" }) }}
+      pipelineTasks={["build"]}
+      filesByTypeForItem={() => emptyFiles}
+      geometryAdapter={geometryAdapter}
+    />,
+  );
+
+  expect(view.container.querySelector('[data-role="restart-badge"]')).toBeNull();
+
+  const viewZero = render(
+    <DAGGrid
+      items={[makeItem({ id: "build", title: "Build", status: "pending", restartCount: 0 })]}
+      jobId="job-1"
+      taskById={{ build: makeTaskState({ name: "build", state: "pending" }) }}
+      pipelineTasks={["build"]}
+      filesByTypeForItem={() => emptyFiles}
+      geometryAdapter={geometryAdapter}
+    />,
+  );
+
+  expect(viewZero.container.querySelector('[data-role="restart-badge"]')).toBeNull();
+});
+
+test("DAGGrid renders the restart badge with singular label when restartCount is 1", () => {
+  installMatchMedia();
+
+  const view = render(
+    <DAGGrid
+      items={[makeItem({ id: "build", title: "Build", status: "pending", restartCount: 1 })]}
+      jobId="job-1"
+      taskById={{ build: makeTaskState({ name: "build", state: "pending" }) }}
+      pipelineTasks={["build"]}
+      filesByTypeForItem={() => emptyFiles}
+      geometryAdapter={geometryAdapter}
+    />,
+  );
+
+  const badge = view.container.querySelector('[data-role="restart-badge"]');
+  expect(badge).not.toBeNull();
+  expect(badge!.getAttribute("aria-label")).toBe("Restarted 1 time");
+  expect(badge!.getAttribute("title")).toBe("Restarted 1 time");
+  expect(badge!.textContent).toBe("↻ 1");
+});
+
+test("DAGGrid renders the restart badge with plural label when restartCount is greater than 1", () => {
+  installMatchMedia();
+
+  const view = render(
+    <DAGGrid
+      items={[makeItem({ id: "build", title: "Build", status: "pending", restartCount: 5 })]}
+      jobId="job-1"
+      taskById={{ build: makeTaskState({ name: "build", state: "pending" }) }}
+      pipelineTasks={["build"]}
+      filesByTypeForItem={() => emptyFiles}
+      geometryAdapter={geometryAdapter}
+    />,
+  );
+
+  const badge = view.container.querySelector('[data-role="restart-badge"]');
+  expect(badge).not.toBeNull();
+  expect(badge!.getAttribute("aria-label")).toBe("Restarted 5 times");
+  expect(badge!.textContent).toBe("↻ 5");
+});
+
+test("DAGGrid renders the restart badge as the first child of the card header", () => {
+  installMatchMedia();
+
+  const view = render(
+    <DAGGrid
+      items={[makeItem({ id: "build", title: "Build", status: "pending", restartCount: 2 })]}
+      jobId="job-1"
+      taskById={{ build: makeTaskState({ name: "build", state: "pending" }) }}
+      pipelineTasks={["build"]}
+      filesByTypeForItem={() => emptyFiles}
+      geometryAdapter={geometryAdapter}
+    />,
+  );
+
+  const header = view.container.querySelector('[data-role="card-header"]');
+  expect(header).not.toBeNull();
+  const firstChild = header!.firstElementChild;
+  expect(firstChild).not.toBeNull();
+  expect(firstChild!.getAttribute("data-role")).toBe("restart-badge");
+});

--- a/src/ui/components/__tests__/JobDetail.test.tsx
+++ b/src/ui/components/__tests__/JobDetail.test.tsx
@@ -1,0 +1,62 @@
+import "./test-dom";
+
+import { render } from "@testing-library/react";
+import { afterEach, expect, mock, test } from "bun:test";
+
+import type { DagItem, JobDetail as JobDetailType, PipelineType } from "../types";
+
+const capturedItems: DagItem[][] = [];
+
+mock.module("../DAGGrid", () => ({
+  default: ({ items }: { items: DagItem[] }) => {
+    capturedItems.push(items);
+    return null;
+  },
+}));
+
+const JobDetail = (await import("../JobDetail")).default;
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  capturedItems.length = 0;
+});
+
+function makeJob(restartCount: number): JobDetailType {
+  return {
+    id: "job-1",
+    name: "Job One",
+    status: "running",
+    tasks: {
+      build: {
+        name: "build",
+        state: "running",
+        startedAt: 1_000,
+        files: { artifacts: [], logs: [], tmp: [] },
+        restartCount,
+      },
+    },
+    pipeline: { tasks: ["build"] },
+    current: "build",
+  };
+}
+
+const pipeline: PipelineType = {
+  name: "Test",
+  slug: "test",
+  description: "",
+  tasks: [{ name: "build" }],
+};
+
+test("JobDetail re-emits dag item when only restartCount changes", () => {
+  const view = render(<JobDetail job={makeJob(1)} pipeline={pipeline} />);
+  expect(capturedItems.length).toBeGreaterThan(0);
+  const firstItems = capturedItems[capturedItems.length - 1] as DagItem[];
+  const firstBuild = firstItems.find((item) => item.id === "build");
+  expect(firstBuild?.restartCount).toBe(1);
+
+  view.rerender(<JobDetail job={makeJob(2)} pipeline={pipeline} />);
+  const lastItems = capturedItems[capturedItems.length - 1] as DagItem[];
+  const secondBuild = lastItems.find((item) => item.id === "build");
+  expect(secondBuild?.restartCount).toBe(2);
+  expect(secondBuild).not.toBe(firstBuild);
+});

--- a/src/ui/components/types.ts
+++ b/src/ui/components/types.ts
@@ -43,6 +43,7 @@ export interface TaskStateObject {
   artifacts?: string[];
   tokenUsage?: Record<string, unknown>;
   attempts?: number;
+  restartCount?: number | null;
   executionTimeMs?: number;
 }
 
@@ -105,6 +106,7 @@ export interface DagItem {
   body: string | null;
   startedAt: string | number;
   endedAt: string | number | null;
+  restartCount?: number;
 }
 
 export interface PipelineTask {

--- a/src/ui/server/__tests__/job-control-endpoints.test.ts
+++ b/src/ui/server/__tests__/job-control-endpoints.test.ts
@@ -221,6 +221,73 @@ describe("handleJobStop", () => {
     expect(analysis.tokenUsage).toEqual([]);
   });
 
+  it("resets restartCount on the running task that gets reset to pending", async () => {
+    const root = await makeTempRoot();
+    initPATHS(root);
+
+    const jobDir = await setupJob(root, "job-restart-count", {
+      id: "job-restart-count",
+      state: "running",
+      current: "analysis",
+      currentStage: "stage-2",
+      tasks: {
+        research: { state: "done", currentStage: null },
+        analysis: {
+          state: "running",
+          currentStage: "stage-2",
+          attempts: 1,
+          restartCount: 2,
+        },
+      },
+      files: { artifacts: [], logs: [], tmp: [] },
+    });
+
+    const req = new Request("http://localhost/api/jobs/job-restart-count/stop", { method: "POST" });
+    const res = await handleJobStop(req, "job-restart-count", root);
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(res.status).toBe(202);
+    expect(body["resetTask"]).toBe("analysis");
+
+    const snapshot = await readJobStatus(jobDir);
+    const analysis = snapshot!.tasks["analysis"]!;
+    expect(analysis.state).toBe("pending");
+    expect(analysis.restartCount).toBe(0);
+  });
+
+  it("does not modify restartCount on tasks that are not reset", async () => {
+    const root = await makeTempRoot();
+    initPATHS(root);
+
+    const jobDir = await setupJob(root, "job-restart-count-untouched", {
+      id: "job-restart-count-untouched",
+      state: "running",
+      current: "analysis",
+      currentStage: "stage-2",
+      tasks: {
+        research: { state: "done", currentStage: null, restartCount: 4 },
+        analysis: {
+          state: "running",
+          currentStage: "stage-2",
+          attempts: 1,
+          restartCount: 1,
+        },
+      },
+      files: { artifacts: [], logs: [], tmp: [] },
+    });
+
+    const req = new Request("http://localhost/api/jobs/job-restart-count-untouched/stop", { method: "POST" });
+    const res = await handleJobStop(req, "job-restart-count-untouched", root);
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(res.status).toBe(202);
+    expect(body["resetTask"]).toBe("analysis");
+
+    const snapshot = await readJobStatus(jobDir);
+    expect(snapshot!.tasks["research"]!.restartCount).toBe(4);
+    expect(snapshot!.tasks["analysis"]!.restartCount).toBe(0);
+  });
+
   it("recovers a stale job by resetting the first non-terminal task after partial progress", async () => {
     const root = await makeTempRoot();
     initPATHS(root);

--- a/src/ui/server/__tests__/job-control-endpoints.test.ts
+++ b/src/ui/server/__tests__/job-control-endpoints.test.ts
@@ -847,6 +847,94 @@ describe("stop → restart integration", () => {
     expect(body["code"]).toBe("job_running");
   });
 
+  it("restart returns 409 job_running while runner is mid-retry-sleep (alive PID, task running, restartCount > 0)", async () => {
+    const root = await makeTempRoot();
+    initPATHS(root);
+
+    // Simulate the runner being asleep between automatic retries: the runner
+    // process is alive, the task it owns is still in "running" state, and
+    // restartCount has already been incremented by the prior failed attempt.
+    const proc = spawnSleeper();
+
+    await setupJob(root, "retry-sleep-restart", {
+      id: "retry-sleep-restart",
+      state: "running",
+      current: "research",
+      currentStage: null,
+      tasks: {
+        research: {
+          state: "running",
+          currentStage: null,
+          attempts: 2,
+          restartCount: 1,
+        },
+      },
+      files: { artifacts: [], logs: [], tmp: [] },
+    }, proc.pid);
+
+    const req = new Request("http://localhost/api/jobs/retry-sleep-restart/restart", { method: "POST" });
+    const res = await handleJobRestart(req, "retry-sleep-restart", root);
+    const body = await res.json() as Record<string, unknown>;
+
+    // The PID-liveness check fires before any task-state inspection, so the
+    // in-flight Bun.sleep cannot race with a manual restart.
+    expect(res.status).toBe(409);
+    expect(body["code"]).toBe("job_running");
+  });
+
+  it("stop terminates a runner mid-retry-sleep within KILL_GRACE_MS + KILL_POLL_MS via SIGTERM", async () => {
+    const root = await makeTempRoot();
+    initPATHS(root);
+
+    // Same scenario as above: runner alive, task running, retry counter set.
+    // The stop path must signal the runner via the existing PID/SIGTERM contract.
+    const proc = spawnSleeper();
+    const pid = proc.pid;
+
+    const jobDir = await setupJob(root, "retry-sleep-stop", {
+      id: "retry-sleep-stop",
+      state: "running",
+      current: "research",
+      currentStage: null,
+      tasks: {
+        research: {
+          state: "running",
+          currentStage: null,
+          attempts: 2,
+          restartCount: 1,
+        },
+      },
+      files: { artifacts: [], logs: [], tmp: [] },
+    }, pid);
+
+    // KILL_GRACE_MS = 1500, KILL_POLL_MS = 100 in job-control-endpoints.ts.
+    // Allow a generous margin for filesystem and signal-delivery jitter while
+    // still asserting the bound holds.
+    const KILL_BUDGET_MS = 1500 + 100 + 500;
+
+    const start = Date.now();
+    const req = new Request("http://localhost/api/jobs/retry-sleep-stop/stop", { method: "POST" });
+    const res = await handleJobStop(req, "retry-sleep-stop", root);
+    const elapsed = Date.now() - start;
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(res.status).toBe(202);
+    expect(body["ok"]).toBe(true);
+    expect(body["stopped"]).toBe(true);
+    expect(body["signal"]).toBe("SIGTERM");
+    expect(body["resetTask"]).toBe("research");
+    expect(elapsed).toBeLessThan(KILL_BUDGET_MS);
+
+    // PID file is removed by cleanupRunnerPid in handleJobStop.
+    const pidFileExists = await Bun.file(path.join(jobDir, "runner.pid")).exists();
+    expect(pidFileExists).toBe(false);
+
+    // Reset restored the task to pending and zeroed restartCount (criterion 10).
+    const snapshot = await readJobStatus(jobDir);
+    expect(snapshot!.tasks["research"]!.state).toBe("pending");
+    expect(snapshot!.tasks["research"]!.restartCount).toBe(0);
+  });
+
   it("full cycle: stop clears running task, restart resets all tasks to pending", async () => {
     const root = await makeTempRoot();
     initPATHS(root);

--- a/src/ui/server/endpoints/job-control-endpoints.ts
+++ b/src/ui/server/endpoints/job-control-endpoints.ts
@@ -418,6 +418,7 @@ export async function handleJobStop(
           delete task.failedStage;
           delete task.error;
           task.attempts = 0;
+          task.restartCount = 0;
           task.refinementAttempts = 0;
           task.tokenUsage = [];
         }

--- a/src/ui/state/transformers/__tests__/status-transformer.test.ts
+++ b/src/ui/state/transformers/__tests__/status-transformer.test.ts
@@ -85,6 +85,21 @@ describe("status-transformer", () => {
     expect(job?.status).toBe("running");
   });
 
+  it("maps numeric restartCount on tasks", () => {
+    const tasks = transformTasks({ alpha: { state: "running", restartCount: 4 } });
+    expect(tasks.alpha?.restartCount).toBe(4);
+  });
+
+  it("treats non-numeric restartCount as undefined", () => {
+    const tasks = transformTasks({ alpha: { state: "running", restartCount: "x" } });
+    expect(tasks.alpha?.restartCount).toBeUndefined();
+  });
+
+  it("returns undefined restartCount when key is absent", () => {
+    const tasks = transformTasks({ alpha: { state: "running" } });
+    expect(tasks.alpha?.restartCount).toBeUndefined();
+  });
+
   it("filters failed reads and computes transformation stats", () => {
     const transformed = transformMultipleJobs([
       { ok: true, data: { tasks: { a: { state: "done" } } }, jobId: "job-1", location: "current" },

--- a/src/ui/state/transformers/status-transformer.ts
+++ b/src/ui/state/transformers/status-transformer.ts
@@ -33,6 +33,7 @@ function toTask(name: string, value: unknown): CanonicalTask {
     startedAt: typeof task["startedAt"] === "string" ? task["startedAt"] : null,
     endedAt: typeof task["endedAt"] === "string" ? task["endedAt"] : null,
     attempts: typeof task["attempts"] === "number" ? task["attempts"] : undefined,
+    restartCount: typeof task["restartCount"] === "number" ? task["restartCount"] : undefined,
     executionTimeMs:
       typeof task["executionTimeMs"] === "number" ? task["executionTimeMs"] : undefined,
     refinementAttempts:

--- a/src/ui/state/types.ts
+++ b/src/ui/state/types.ts
@@ -121,6 +121,7 @@ export interface CanonicalTask {
   startedAt?: string | null;
   endedAt?: string | null;
   attempts?: number;
+  restartCount?: number;
   executionTimeMs?: number;
   refinementAttempts?: number;
   stageLogPath?: string;

--- a/src/utils/__tests__/dag.test.ts
+++ b/src/utils/__tests__/dag.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "bun:test";
+import { computeDagItems } from "../dag";
+import type { JobDetail, TaskStateObject } from "../../ui/components/types";
+
+function makeJob(tasks: TaskStateObject[]): JobDetail {
+  return {
+    id: "job-1",
+    name: "job-1",
+    status: "running",
+    tasks,
+    pipeline: { tasks: tasks.map((t) => t.name) },
+    current: null,
+  };
+}
+
+describe("computeDagItems restartCount", () => {
+  it("propagates restartCount from a task", () => {
+    const job = makeJob([{ name: "t1", state: "done", restartCount: 3 }]);
+    const items = computeDagItems(job, { tasks: ["t1"] });
+    expect(items[0]?.restartCount).toBe(3);
+  });
+
+  it("defaults restartCount to 0 when the task lacks it", () => {
+    const job = makeJob([{ name: "t1", state: "done" }]);
+    const items = computeDagItems(job, { tasks: ["t1"] });
+    expect(items[0]?.restartCount).toBe(0);
+  });
+
+  it("defaults restartCount to 0 when the pipeline task is missing from job.tasks", () => {
+    const job = makeJob([]);
+    const items = computeDagItems(job, { tasks: ["t1"] });
+    expect(items).toHaveLength(1);
+    expect(items[0]?.restartCount).toBe(0);
+  });
+});

--- a/src/utils/dag.ts
+++ b/src/utils/dag.ts
@@ -20,6 +20,7 @@ export function computeDagItems(job: JobDetail, pipeline: Pick<PipelineType, "ta
       body: task?.error?.message ?? null,
       startedAt: task?.startedAt ?? 0,
       endedAt: task?.endedAt ?? null,
+      restartCount: task?.restartCount ?? 0,
     } satisfies DagItem;
   });
 }

--- a/tests/core/status-writer.test.ts
+++ b/tests/core/status-writer.test.ts
@@ -732,6 +732,23 @@ describe("resetJobFromTask", () => {
     expect(snapshot.tasks["D"]!.refinementAttempts).toBe(0);
   });
 
+  test("sets restartCount: 0 on fromTask and subsequent tasks but not earlier tasks", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "status-writer-reset-from-rc-"));
+    await writeJobStatus(dir, (s) => {
+      s.tasks["t1"] = { state: "done", restartCount: 4 };
+      s.tasks["t2"] = { state: "failed", restartCount: 2 };
+      s.tasks["t3"] = { state: "pending", restartCount: 1 };
+      s.tasks["t4"] = { state: "pending", restartCount: 3 };
+    });
+
+    const snapshot = await resetJobFromTask(dir, "t2");
+
+    expect(snapshot.tasks["t1"]!.restartCount).toBe(4);
+    expect(snapshot.tasks["t2"]!.restartCount).toBe(0);
+    expect(snapshot.tasks["t3"]!.restartCount).toBe(0);
+    expect(snapshot.tasks["t4"]!.restartCount).toBe(0);
+  });
+
   test("does not recompute or stomp progress from snapshot task-map size", async () => {
     const dir = await makeTempDir();
     await setupSnapshot(dir);
@@ -861,6 +878,21 @@ describe("resetJobToCleanSlate", () => {
     }
   });
 
+  test("sets restartCount: 0 on every task, including those previously at restartCount: 5", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "status-writer-clean-slate-rc-"));
+    await writeJobStatus(dir, (s) => {
+      s.tasks["A"] = { state: "done", restartCount: 5 };
+      s.tasks["B"] = { state: "failed", restartCount: 2 };
+      s.tasks["C"] = { state: "pending" };
+    });
+
+    const snapshot = await resetJobToCleanSlate(dir);
+
+    expect(snapshot.tasks["A"]!.restartCount).toBe(0);
+    expect(snapshot.tasks["B"]!.restartCount).toBe(0);
+    expect(snapshot.tasks["C"]!.restartCount).toBe(0);
+  });
+
   test("files arrays on all tasks are preserved", async () => {
     const dir = await makeTempDir();
     await setupSnapshot(dir);
@@ -950,6 +982,22 @@ describe("resetSingleTask", () => {
     // task-c is unchanged
     expect(snapshot.tasks["task-c"]!.state).toBe("pending");
     expect(snapshot.tasks["task-c"]!.attempts).toBe(0);
+  });
+
+  test("sets restartCount: 0 on the targeted task and leaves restartCount on other tasks unchanged", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "status-writer-single-task-rc-"));
+
+    await writeJobStatus(dir, (s) => {
+      s.tasks["t1"] = { state: "done", restartCount: 3 };
+      s.tasks["t2"] = { state: "failed", restartCount: 4 };
+      s.tasks["t3"] = { state: "pending", restartCount: 2 };
+    });
+
+    const snapshot = await resetSingleTask(dir, "t2");
+
+    expect(snapshot.tasks["t1"]!.restartCount).toBe(3);
+    expect(snapshot.tasks["t2"]!.restartCount).toBe(0);
+    expect(snapshot.tasks["t3"]!.restartCount).toBe(2);
   });
 
   test("resetting a non-existent task creates it with pending state", async () => {


### PR DESCRIPTION
Closes #286.

## Summary

- Add `taskRunner.maxAttempts` (default 3, env override `PO_TASK_MAX_ATTEMPTS`) — a global per-task automatic retry budget.
- When a task fails, `pipeline-runner` now retries up to `maxAttempts` total tries with exponential backoff (2s → 4s → … capped at 30s) before marking the task `failed` and exiting.
- Track retries in a new `restartCount` field on each task entry, plumbed end-to-end through status snapshot → state transformer → client adapter → `DagItem`.
- DAG card header renders a red `↻ N` badge in the top-left when `restartCount > 0`, with `aria-label="Restarted N time(s)"`.
- All manual reset paths (`resetJobToCleanSlate`, `resetSingleTask`, `resetJobFromTask`, `handleJobStop`) zero `restartCount` so a manual intervention starts the auto-retry budget over.
- `JobDetail` reuse-comparison now includes `restartCount`, so the badge updates live mid-retry.

## Implementation

12 commits, one per spec step:

- `feat(config)`: add `taskRunner.maxAttempts` global retry limit
- `feat(status-writer)`: add `restartCount` field with reset-path zeroing
- `feat(pipeline-runner)`: add `restartCount` to `TaskStatus` type
- `feat(ui)`: add `restartCount` to canonical, normalized, and DAG task types
- `feat(pipeline-runner)`: retry failing tasks up to `maxAttempts` with exponential backoff
- `feat(status-transformer)`: map `restartCount` onto `CanonicalTask`
- `feat(job-adapter)`: map `restartCount` onto `NormalizedTask`
- `feat(dag)`: populate `restartCount` on `DagItem`
- `fix(JobDetail)`: include `restartCount` in `DagItem` reuse comparison
- `feat(DAGGrid)`: render restart badge in card header when `restartCount > 0`
- `fix(job-control)`: reset `restartCount` when `handleJobStop` resets in-flight task
- `test(job-control)`: verify restart/stop contract during retry sleep

## Design decisions

- **In-process retry, not orchestrator respawn.** The minimal correct fix is a loop around `runPipeline`; recovery from runner-process crashes (SIGKILL/OOM) still requires a manual restart, but those weren't in scope.
- **Separate `restartCount` from `attempts`.** `attempts` is "total invocations" (incremented on manual restart too); `restartCount` is the explicit user-facing "auto-retries since last reset" the badge shows. Keeps the badge stable across future `attempts` semantics changes.
- **Always retry, no error classification.** Both intermittent and logic-flaw failures look identical at the runner boundary; the budget naturally surfaces logic flaws as `failed` after exhaustion.
- **Backoff constants live in code, not config.** Avoids surfacing a knob nobody will tune correctly.

## No migration needed

`restartCount` is optional, defaults to `0` when read, written lazily on first retry. Existing `tasks-status.json` snapshots remain valid.

## Test plan

- [x] Unit: config defaults, validation, env override
- [x] Unit: `restartCount` reset on all four reset paths (`resetJobFromTask`, `resetJobToCleanSlate`, `resetSingleTask`, `handleJobStop`)
- [x] Unit: retry loop call counts, final state, `restartCount` increments, backoff delay sequence `[2000, 4000]`
- [x] Unit: `status-transformer` and `job-adapter` map numeric/non-numeric/absent values correctly
- [x] Unit: `computeDagItems` defaults `restartCount` to `0` when task entry missing
- [x] Unit: `JobDetail` reuse-comparison includes `restartCount`
- [x] Unit: `DAGGrid` renders badge as first child of `[data-role="card-header"]`, singular vs plural `aria-label`
- [x] Integration: `/restart` returns 409 while runner is mid-retry-sleep; `/stop` terminates runner within `KILL_GRACE_MS + KILL_POLL_MS`
- [ ] Manual: visually verify badge styling in browser before merge