### PR TITLE
Harden task retry follow-up

### DIFF
--- a/src/core/__tests__/config.test.ts
+++ b/src/core/__tests__/config.test.ts
@@ -97,7 +97,28 @@ describe("validateConfig (via loadConfig)", () => {
     const origRoot = process.env.PO_ROOT;
     process.env.PO_ROOT = dir;
     try {
-      await expect(loadConfig({ configPath: overrideFile })).rejects.toThrow("taskRunner.maxAttempts must be >= 1");
+      await expect(loadConfig({ configPath: overrideFile })).rejects.toThrow("taskRunner.maxAttempts must be an integer >= 1");
+    } finally {
+      if (origRoot) process.env.PO_ROOT = origRoot; else delete process.env.PO_ROOT;
+      await rm(dir, { recursive: true });
+    }
+  });
+
+  test("throws when taskRunner.maxAttempts is non-integer", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "config-test-"));
+    const configDir = join(dir, "pipeline-config", "test");
+    const tasksDir = join(configDir, "tasks");
+    await mkdir(tasksDir, { recursive: true });
+    await writeFile(join(configDir, "pipeline.json"), JSON.stringify({ name: "test", tasks: ["t1"] }));
+    await writeFile(join(dir, "pipeline-config", "registry.json"), JSON.stringify({
+      pipelines: { test: { configDir, tasksDir } }
+    }));
+    const overrideFile = join(dir, "config.json");
+    await writeFile(overrideFile, JSON.stringify({ taskRunner: { maxAttempts: 2.5 } }));
+    const origRoot = process.env.PO_ROOT;
+    process.env.PO_ROOT = dir;
+    try {
+      await expect(loadConfig({ configPath: overrideFile })).rejects.toThrow("taskRunner.maxAttempts must be an integer >= 1");
     } finally {
       if (origRoot) process.env.PO_ROOT = origRoot; else delete process.env.PO_ROOT;
       await rm(dir, { recursive: true });
@@ -116,6 +137,18 @@ describe("PO_TASK_MAX_ATTEMPTS env override", () => {
     resetConfig();
     const config: AppConfig = getConfig();
     expect(config.taskRunner.maxAttempts).toBe(5);
+  });
+
+  test("getConfig rejects non-numeric PO_TASK_MAX_ATTEMPTS values", () => {
+    process.env.PO_TASK_MAX_ATTEMPTS = "abc";
+    resetConfig();
+    expect(() => getConfig()).toThrow("PO_TASK_MAX_ATTEMPTS must be an integer >= 1");
+  });
+
+  test("getConfig rejects non-integer PO_TASK_MAX_ATTEMPTS values", () => {
+    process.env.PO_TASK_MAX_ATTEMPTS = "2.5";
+    resetConfig();
+    expect(() => getConfig()).toThrow("PO_TASK_MAX_ATTEMPTS must be an integer >= 1");
   });
 });
 

--- a/src/core/__tests__/pipeline-runner.test.ts
+++ b/src/core/__tests__/pipeline-runner.test.ts
@@ -324,7 +324,7 @@ describe("runPipelineJob — outer-catch failure surfacing", () => {
 
     const fakeTimer = { unref: () => fakeTimer, ref: () => fakeTimer };
     const setTimeoutSpy = spyOn(globalThis, "setTimeout").mockImplementation(
-      (() => fakeTimer as unknown as ReturnType<typeof setTimeout>) as typeof setTimeout,
+      ((() => fakeTimer as unknown as ReturnType<typeof setTimeout>) as unknown) as typeof setTimeout,
     );
 
     const consoleErrorMessages: unknown[][] = [];
@@ -458,11 +458,11 @@ describe("runPipelineJob — bounded retry loop", () => {
 
     const statusText = await readFile(join(fixture.jobDir, "tasks-status.json"), "utf-8");
     const status = JSON.parse(statusText) as {
-      tasks: Record<string, { state?: string; restartCount?: number }>;
+      tasks: Record<string, { state?: string; attempts?: number; restartCount?: number }>;
     };
     expect(status.tasks["task-a"]?.state).toBe("failed");
-    const rc = status.tasks["task-a"]?.restartCount;
-    expect(rc === undefined || rc === 0).toBe(true);
+    expect(status.tasks["task-a"]?.restartCount).toBeUndefined();
+    expect(status.tasks["task-a"]?.attempts).toBe(1);
   });
 
   test("maxAttempts: 3 — fails twice then succeeds: three calls, restartCount=2, exits zero", async () => {
@@ -496,9 +496,10 @@ describe("runPipelineJob — bounded retry loop", () => {
 
     const statusText = await readFile(fixture.statusPath, "utf-8");
     const status = JSON.parse(statusText) as {
-      tasks: Record<string, { state?: string; restartCount?: number }>;
+      tasks: Record<string, { state?: string; attempts?: number; restartCount?: number }>;
     };
     expect(status.tasks["task-a"]?.state).toBe("done");
+    expect(status.tasks["task-a"]?.attempts).toBe(3);
     expect(status.tasks["task-a"]?.restartCount).toBe(2);
   });
 
@@ -529,9 +530,10 @@ describe("runPipelineJob — bounded retry loop", () => {
 
     const statusText = await readFile(join(fixture.jobDir, "tasks-status.json"), "utf-8");
     const status = JSON.parse(statusText) as {
-      tasks: Record<string, { state?: string; restartCount?: number }>;
+      tasks: Record<string, { state?: string; attempts?: number; restartCount?: number }>;
     };
     expect(status.tasks["task-a"]?.state).toBe("failed");
+    expect(status.tasks["task-a"]?.attempts).toBe(3);
     expect(status.tasks["task-a"]?.restartCount).toBe(2);
   });
 
@@ -541,7 +543,7 @@ describe("runPipelineJob — bounded retry loop", () => {
     cleanupDirs.push(fixture.tmpDir);
 
     let call = 0;
-    let interimSnapshot: { state?: string; failedStage?: unknown; error?: unknown; restartCount?: number } | undefined;
+    let interimSnapshot: { state?: string; attempts?: number; failedStage?: unknown; error?: unknown; restartCount?: number } | undefined;
 
     // Capture the snapshot from disk *during* the second call (after the first failure
     // and the interim writeJobStatus). At call #2 we read tasks-status.json, then
@@ -551,7 +553,7 @@ describe("runPipelineJob — bounded retry loop", () => {
       if (call === 2) {
         const text = await readFile(join(fixture.jobDir, "tasks-status.json"), "utf-8");
         const parsed = JSON.parse(text) as {
-          tasks: Record<string, { state?: string; failedStage?: unknown; error?: unknown; restartCount?: number }>;
+          tasks: Record<string, { state?: string; attempts?: number; failedStage?: unknown; error?: unknown; restartCount?: number }>;
         };
         interimSnapshot = parsed.tasks["task-a"];
         return makeSuccessResult() as never;
@@ -575,6 +577,52 @@ describe("runPipelineJob — bounded retry loop", () => {
     expect(interimSnapshot?.state).toBe("running");
     expect(interimSnapshot?.failedStage).toBeUndefined();
     expect(interimSnapshot?.error).toBeUndefined();
+    expect(interimSnapshot?.attempts).toBe(2);
     expect(interimSnapshot?.restartCount).toBe(1);
+  });
+
+  test("missing taskRunner config falls back to the default retry cap", async () => {
+    mockGetConfig.mockImplementation(() => ({} as never));
+    const fixture = await setupMultiTaskFixture(["task-a"]);
+    cleanupDirs.push(fixture.tmpDir);
+
+    let call = 0;
+    mockRunPipeline.mockImplementation(async () => {
+      call += 1;
+      return (call === 1 ? makeFailureResult() : makeSuccessResult()) as never;
+    });
+
+    await runPipelineJob(fixture.jobId);
+
+    expect(mockRunPipeline.mock.calls.length).toBe(2);
+    expect(sleepDelays).toEqual([2000]);
+  });
+
+  test("exceptions from runPipeline bypass result retries and surface through outer failure handling", async () => {
+    mockGetConfig.mockImplementation(() => ({ taskRunner: { maxAttempts: 3 } }));
+    const fixture = await setupMultiTaskFixture(["task-a"]);
+    cleanupDirs.push(fixture.tmpDir);
+
+    mockRunPipeline.mockImplementation(async () => {
+      throw new Error("task module exploded");
+    });
+
+    const exitCalls: Array<number | undefined> = [];
+    const exitSpy = spyOn(process, "exit").mockImplementation(((code?: number) => {
+      exitCalls.push(code);
+      throw new Error(`__test_exit__:${String(code)}`);
+    }) as typeof process.exit);
+
+    try {
+      await runPipelineJob(fixture.jobId);
+    } catch (e) {
+      if (!(e instanceof Error) || !/^__test_exit__:/.test(e.message)) throw e;
+    } finally {
+      exitSpy.mockRestore();
+    }
+
+    expect(mockRunPipeline.mock.calls.length).toBe(1);
+    expect(sleepDelays).toEqual([]);
+    expect(exitCalls).toContain(1);
   });
 });

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -188,7 +188,14 @@ function loadFromEnvironment(config: AppConfig): AppConfig {
 
   const maxAttemptsRaw = process.env["PO_TASK_MAX_ATTEMPTS"];
   if (maxAttemptsRaw) {
-    overrides["taskRunner"] = { maxAttempts: parseInt(maxAttemptsRaw, 10) };
+    const maxAttempts = Number(maxAttemptsRaw);
+    if (!Number.isInteger(maxAttempts) || maxAttempts < 1) {
+      throw new Error(`PO_TASK_MAX_ATTEMPTS must be an integer >= 1, got ${maxAttemptsRaw}`);
+    }
+    overrides["taskRunner"] = {
+      ...((overrides["taskRunner"] as PlainObject | undefined) ?? {}),
+      maxAttempts,
+    };
   }
 
   const shutdownTimeoutRaw = process.env["PO_SHUTDOWN_TIMEOUT"];
@@ -234,8 +241,8 @@ function validateConfig(config: AppConfig): void {
   if (config.taskRunner.maxRefinementAttempts < 1) {
     errors.push(`taskRunner.maxRefinementAttempts must be >= 1, got ${config.taskRunner.maxRefinementAttempts}`);
   }
-  if (config.taskRunner.maxAttempts < 1) {
-    errors.push(`taskRunner.maxAttempts must be >= 1, got ${config.taskRunner.maxAttempts}`);
+  if (!Number.isInteger(config.taskRunner.maxAttempts) || config.taskRunner.maxAttempts < 1) {
+    errors.push(`taskRunner.maxAttempts must be an integer >= 1, got ${config.taskRunner.maxAttempts}`);
   }
   if (!(VALID_LOG_LEVELS as readonly string[]).includes(config.logging.level)) {
     errors.push(`logging.level must be one of ${VALID_LOG_LEVELS.join(", ")}, got ${config.logging.level}`);

--- a/src/core/pipeline-runner.ts
+++ b/src/core/pipeline-runner.ts
@@ -420,8 +420,8 @@ export async function runPipelineJob(jobId: string): Promise<void> {
     };
 
     // Delegate to task runner with bounded retry loop.
-    // Guard against test mocks that may return a non-integer maxAttempts.
-    const configuredMaxAttempts = getConfig().taskRunner.maxAttempts;
+    // Guard against partial test mocks or malformed runtime config.
+    const configuredMaxAttempts = getConfig().taskRunner?.maxAttempts;
     const maxAttempts = Number.isInteger(configuredMaxAttempts) ? configuredMaxAttempts : 3;
     const cap = Math.max(1, maxAttempts);
 
@@ -437,13 +437,14 @@ export async function runPipelineJob(jobId: string): Promise<void> {
       );
 
       await writeJobStatus(config.workDir, (snapshot) => {
-        const entry = (snapshot.tasks[taskName] ?? {}) as Record<string, unknown>;
-        entry["state"] = "running";
-        entry["attempts"] = ((entry["attempts"] as number | undefined) ?? 1) + 1;
-        entry["restartCount"] = ((entry["restartCount"] as number | undefined) ?? 0) + 1;
-        delete entry["failedStage"];
-        delete entry["error"];
-        snapshot.tasks[taskName] = entry as typeof snapshot.tasks[string];
+        const entry = snapshot.tasks[taskName] ?? {};
+        const currentAttempts = typeof entry.attempts === "number" ? entry.attempts : attempt;
+        entry.state = "running";
+        entry.attempts = currentAttempts + 1;
+        entry.restartCount = (entry.restartCount ?? 0) + 1;
+        delete entry.failedStage;
+        delete entry.error;
+        snapshot.tasks[taskName] = entry;
       });
 
       await Bun.sleep(delay);

--- a/src/core/task-runner.ts
+++ b/src/core/task-runner.ts
@@ -795,7 +795,7 @@ export async function runPipeline(
 
   // Write done status (best-effort)
   try {
-    const lastStage = KNOWN_STAGES[KNOWN_STAGES.length - 1];
+    const lastStage = KNOWN_STAGES.at(-1)!;
     const doneProgress = computeDeterministicProgress(
       pipelineTasks ?? [taskName],
       taskName,

--- a/src/ui/components/DAGGrid.tsx
+++ b/src/ui/components/DAGGrid.tsx
@@ -286,7 +286,7 @@ export default function DAGGrid({
                     ↻ {items[index]!.restartCount}
                   </span>
                 ) : null}
-                <div className="truncate font-medium">{items[index]?.title ?? formatStepName(items[index]?.id ?? "")}</div>
+                <div className="min-w-0 flex-1 truncate text-left font-medium">{items[index]?.title ?? formatStepName(items[index]?.id ?? "")}</div>
                 <div className="flex items-center gap-2">
                   {getItemStatus(items[index], index, activeIndex) === "running" ? (
                     <>

--- a/src/ui/components/types.ts
+++ b/src/ui/components/types.ts
@@ -43,7 +43,7 @@ export interface TaskStateObject {
   artifacts?: string[];
   tokenUsage?: Record<string, unknown>;
   attempts?: number;
-  restartCount?: number | null;
+  restartCount?: number;
   executionTimeMs?: number;
 }
 

--- a/tests/core/pipeline-runner.integration.test.ts
+++ b/tests/core/pipeline-runner.integration.test.ts
@@ -8,12 +8,14 @@ import { join } from "node:path";
 
 // ─── Mock config ──────────────────────────────────────────────────────────────
 
+const mockGetConfig = mock(() => ({}));
+
 mock.module("../../src/core/config", () => ({
   getPipelineConfig: mock((_slug: string) => ({
     pipelineJsonPath: "/mock/pipeline.json",
     tasksDir: "/mock/tasks",
   })),
-  getConfig: mock(() => ({})),
+  getConfig: mockGetConfig,
   loadConfig: mock(async () => ({})),
   resetConfig: mock(() => {}),
 }));
@@ -181,6 +183,7 @@ const PO_ENV_KEYS = [
   "PO_TASK_REGISTRY",
   "PO_START_FROM_TASK",
   "PO_RUN_SINGLE_TASK",
+  "PO_TASK_MAX_ATTEMPTS",
 ] as const;
 
 // ─── Integration test ─────────────────────────────────────────────────────────
@@ -248,6 +251,8 @@ describe("runPipelineJob — full lifecycle integration", () => {
     }));
     mockWriteJobStatusReal.mockClear();
     mockCleanupTaskSymlinks.mockClear();
+    mockGetConfig.mockReset();
+    mockGetConfig.mockImplementation(() => ({}));
   });
 
   afterEach(() => {
@@ -259,6 +264,7 @@ describe("runPipelineJob — full lifecycle integration", () => {
         process.env[key] = savedEnv[key];
       }
     }
+    process.exitCode = 0;
   });
 
   test("multi-task pipeline: snapshot.state transitions through running then done", async () => {
@@ -321,6 +327,8 @@ describe("runPipelineJob — full lifecycle integration", () => {
   });
 
   test("task failure path: job-level state is set to failed", async () => {
+    mockGetConfig.mockImplementation(() => ({ taskRunner: { maxAttempts: 1 } }));
+
     // Make task-a fail
     mockRunPipeline.mockImplementation(async (_modulePath: string, _ctx: unknown) => ({
       ok: false as const,

--- a/tests/core/pipeline-runner.test.ts
+++ b/tests/core/pipeline-runner.test.ts
@@ -11,10 +11,11 @@ const mockGetPipelineConfig = mock((_slug: string) => ({
   pipelineJsonPath: "/mock/pipelines/test-pipeline/pipeline.json",
   tasksDir: "/mock/pipelines/test-pipeline/tasks",
 }));
+const mockGetConfig = mock(() => ({ taskRunner: { maxAttempts: 1 } }));
 
 mock.module("../../src/core/config", () => ({
   getPipelineConfig: mockGetPipelineConfig,
-  getConfig: mock(() => ({})),
+  getConfig: mockGetConfig,
   loadConfig: mock(async () => ({})),
   resetConfig: mock(() => {}),
 }));
@@ -600,6 +601,8 @@ describe("runPipelineJob", () => {
     mockWriteJobStatus.mockClear();
     mockDecideTransition.mockClear();
     mockDecideTransition.mockImplementation((_input: unknown) => ({ ok: true as const }));
+    mockGetConfig.mockReset();
+    mockGetConfig.mockImplementation(() => ({ taskRunner: { maxAttempts: 1 } }));
     mockGetPipelineConfig.mockClear();
     mockLoadFreshModule.mockClear();
     mockValidatePipelineOrThrow.mockClear();


### PR DESCRIPTION
## Summary
- reject invalid and fractional PO_TASK_MAX_ATTEMPTS values
- require taskRunner.maxAttempts to be an integer >= 1 in config validation
- remove the untyped retry status cast and align restartCount typing

Follow-up to #287. Refs #286.

## Validation
- bun run typecheck
- bun run test