### PR TITLE
Refresh provider model registry

### DIFF
--- a/src/config/__tests__/models.test.ts
+++ b/src/config/__tests__/models.test.ts
@@ -15,7 +15,7 @@ import {
 } from "../models";
 import type { ModelConfigEntry } from "../models";
 
-const MODEL_COUNT = 41;
+const MODEL_COUNT = 50;
 const PROVIDER_COUNT = 8;
 
 describe("ModelAlias", () => {
@@ -110,8 +110,8 @@ describe("DEFAULT_MODEL_BY_PROVIDER", () => {
 });
 
 describe("aliasToFunctionName", () => {
-  it('converts "openai:gpt-5.2" to "gpt52"', () => {
-    expect(aliasToFunctionName("openai:gpt-5.2")).toBe("gpt52");
+  it('converts "openai:gpt-5.4" to "gpt54"', () => {
+    expect(aliasToFunctionName("openai:gpt-5.4")).toBe("gpt54");
   });
 
   it('converts "gemini:flash-2.5-lite" to "flash25Lite"', () => {
@@ -137,8 +137,8 @@ describe("aliasToFunctionName", () => {
 });
 
 describe("getProviderFromAlias", () => {
-  it('returns "openai" for "openai:gpt-5.2"', () => {
-    expect(getProviderFromAlias("openai:gpt-5.2")).toBe("openai");
+  it('returns "openai" for "openai:gpt-5.4"', () => {
+    expect(getProviderFromAlias("openai:gpt-5.4")).toBe("openai");
   });
 
   it("throws for non-string input", () => {
@@ -152,8 +152,8 @@ describe("getProviderFromAlias", () => {
 });
 
 describe("getModelFromAlias", () => {
-  it('returns "gpt-5.2" for "openai:gpt-5.2"', () => {
-    expect(getModelFromAlias("openai:gpt-5.2")).toBe("gpt-5.2");
+  it('returns "gpt-5.4" for "openai:gpt-5.4"', () => {
+    expect(getModelFromAlias("openai:gpt-5.4")).toBe("gpt-5.4");
   });
 
   it("handles multiple colons by rejoining segments after first", () => {
@@ -171,10 +171,25 @@ describe("getModelFromAlias", () => {
 });
 
 describe("getModelConfig", () => {
-  it('returns config for "openai:gpt-5.2" with provider "openai"', () => {
-    const config = getModelConfig("openai:gpt-5.2");
+  it('returns config for "openai:gpt-5.4" with provider "openai"', () => {
+    const config = getModelConfig("openai:gpt-5.4");
     expect(config).not.toBeNull();
     expect(config!.provider).toBe("openai");
+  });
+
+  it("returns configs for Alibaba Qwen 3.6 models", () => {
+    expect(getModelConfig("alibaba:qwen3.6-flash")).toMatchObject({
+      provider: "alibaba",
+      model: "qwen3.6-flash",
+    });
+    expect(getModelConfig("alibaba:qwen3.6-plus")).toMatchObject({
+      provider: "alibaba",
+      model: "qwen3.6-plus",
+    });
+    expect(getModelConfig("alibaba:qwen3.6-max-preview")).toMatchObject({
+      provider: "alibaba",
+      model: "qwen3.6-max-preview",
+    });
   });
 
   it("returns null for unknown aliases", () => {
@@ -184,10 +199,20 @@ describe("getModelConfig", () => {
 
   it("returns null for removed aliases", () => {
     expect(getModelConfig("openai:gpt-4")).toBeNull();
+    expect(getModelConfig("openai:gpt-4o")).toBeNull();
+    expect(getModelConfig("openai:gpt-4o-mini")).toBeNull();
+    expect(getModelConfig("openai:gpt-5.2")).toBeNull();
+    expect(getModelConfig("openai:gpt-5.2-pro")).toBeNull();
+    expect(getModelConfig("openai:o3-mini")).toBeNull();
+    expect(getModelConfig("anthropic:haiku-4-6")).toBeNull();
+    expect(getModelConfig("deepseek:deepseek-chat")).toBeNull();
+    expect(getModelConfig("deepseek:deepseek-reasoner")).toBeNull();
     expect(getModelConfig("deepseek:r1")).toBeNull();
+    expect(getModelConfig("moonshot:kimi-k1.5")).toBeNull();
     expect(getModelConfig("moonshot:kimi-moonshot-v1-128k")).toBeNull();
     expect(getModelConfig("gemini:flash-3")).toBeNull();
     expect(getModelConfig("gemini:pro-3")).toBeNull();
+    expect(getModelConfig("zai:glm-5-code")).toBeNull();
     expect(getModelConfig("zai:glm-4-plus")).toBeNull();
   });
 });
@@ -201,12 +226,20 @@ describe("FUNCTION_NAME_BY_ALIAS", () => {
     expect(Object.isFrozen(FUNCTION_NAME_BY_ALIAS)).toBe(true);
   });
 
-  it("has correct value for openai:gpt-5.2", () => {
-    expect(FUNCTION_NAME_BY_ALIAS["openai:gpt-5.2"]).toBe("gpt52");
+  it("has correct value for openai:gpt-5.4", () => {
+    expect(FUNCTION_NAME_BY_ALIAS["openai:gpt-5.4"]).toBe("gpt54");
   });
 
   it("has correct value for gemini:flash-2.5-lite", () => {
     expect(FUNCTION_NAME_BY_ALIAS["gemini:flash-2.5-lite"]).toBe("flash25Lite");
+  });
+
+  it("has correct values for Alibaba Qwen 3.6 models", () => {
+    expect(FUNCTION_NAME_BY_ALIAS["alibaba:qwen3.6-flash"]).toBe("qwen36Flash");
+    expect(FUNCTION_NAME_BY_ALIAS["alibaba:qwen3.6-plus"]).toBe("qwen36Plus");
+    expect(FUNCTION_NAME_BY_ALIAS["alibaba:qwen3.6-max-preview"]).toBe(
+      "qwen36MaxPreview",
+    );
   });
 });
 
@@ -236,6 +269,13 @@ describe("PROVIDER_FUNCTIONS", () => {
         expect(entry.fullPath).toBe(`llm.${provider}.${entry.functionName}`);
       }
     }
+  });
+
+  it("includes callable paths for Alibaba Qwen 3.6 models", () => {
+    const alibabaPaths = PROVIDER_FUNCTIONS.alibaba.map((entry) => entry.fullPath);
+    expect(alibabaPaths).toContain("llm.alibaba.qwen36Flash");
+    expect(alibabaPaths).toContain("llm.alibaba.qwen36Plus");
+    expect(alibabaPaths).toContain("llm.alibaba.qwen36MaxPreview");
   });
 
   it("is frozen (top-level)", () => {

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -27,7 +27,11 @@ function deepFreeze<T>(obj: T): T {
   if (obj === null || typeof obj !== "object") return obj;
   Object.freeze(obj);
   for (const value of Object.values(obj as object)) {
-    if (value !== null && typeof value === "object" && !Object.isFrozen(value)) {
+    if (
+      value !== null &&
+      typeof value === "object" &&
+      !Object.isFrozen(value)
+    ) {
       deepFreeze(value);
     }
   }
@@ -41,12 +45,12 @@ export const ModelAlias = Object.freeze({
   OPENAI_GPT_4_1: "openai:gpt-4-1",
   OPENAI_GPT_4_1_MINI: "openai:gpt-4-1-mini",
   OPENAI_GPT_4_1_NANO: "openai:gpt-4-1-nano",
-  OPENAI_GPT_4O: "openai:gpt-4o",
-  OPENAI_GPT_4O_MINI: "openai:gpt-4o-mini",
-  OPENAI_GPT_5_2: "openai:gpt-5.2",
-  OPENAI_GPT_5_2_PRO: "openai:gpt-5.2-pro",
+  OPENAI_GPT_5_4: "openai:gpt-5.4",
+  OPENAI_GPT_5_4_MINI: "openai:gpt-5.4-mini",
+  OPENAI_GPT_5_4_NANO: "openai:gpt-5.4-nano",
+  OPENAI_GPT_5_5: "openai:gpt-5.5",
+  OPENAI_GPT_5_5_PRO: "openai:gpt-5.5-pro",
   OPENAI_O3: "openai:o3",
-  OPENAI_O3_MINI: "openai:o3-mini",
   OPENAI_O4_MINI: "openai:o4-mini",
   // Anthropic
   ANTHROPIC_OPUS_4_5: "anthropic:opus-4-5",
@@ -54,33 +58,42 @@ export const ModelAlias = Object.freeze({
   ANTHROPIC_HAIKU_4_5: "anthropic:haiku-4-5",
   ANTHROPIC_OPUS_4_6: "anthropic:opus-4-6",
   ANTHROPIC_SONNET_4_6: "anthropic:sonnet-4-6",
-  ANTHROPIC_HAIKU_4_6: "anthropic:haiku-4-6",
+  ANTHROPIC_OPUS_4_7: "anthropic:opus-4-7",
   // Gemini
   GEMINI_FLASH_2_5: "gemini:flash-2.5",
   GEMINI_FLASH_2_5_LITE: "gemini:flash-2.5-lite",
   GEMINI_PRO_2_5: "gemini:pro-2.5",
-  // DeepSeek — cache miss prices
-  DEEPSEEK_CHAT: "deepseek:deepseek-chat",
-  DEEPSEEK_REASONER: "deepseek:deepseek-reasoner",
+  GEMINI_PRO_3_1_PREVIEW: "gemini:pro-3.1-preview",
+  GEMINI_FLASH_3_PREVIEW: "gemini:flash-3-preview",
+  GEMINI_FLASH_3_1_LITE_PREVIEW: "gemini:flash-3.1-lite-preview",
+  // DeepSeek
+  DEEPSEEK_V4_FLASH: "deepseek:v4-flash",
+  DEEPSEEK_V4_PRO: "deepseek:v4-pro",
   // Moonshot / Kimi
   MOONSHOT_KIMI_K2_5: "moonshot:kimi-k2.5",
-  MOONSHOT_KIMI_K1_5: "moonshot:kimi-k1.5",
+  MOONSHOT_KIMI_K2_6: "moonshot:kimi-k2.6",
   // Claude Code — subscription-based, zero token cost
   CLAUDE_CODE_SONNET: "claude-code:sonnet",
   CLAUDE_CODE_OPUS: "claude-code:opus",
   CLAUDE_CODE_HAIKU: "claude-code:haiku",
   // Z.ai
+  ZAI_GLM_5_1: "zai:glm-5-1",
   ZAI_GLM_5: "zai:glm-5",
-  ZAI_GLM_5_CODE: "zai:glm-5-code",
+  ZAI_GLM_5_TURBO: "zai:glm-5-turbo",
   ZAI_GLM_4_7: "zai:glm-4-7",
   ZAI_GLM_4_7_FLASH_X: "zai:glm-4-7-flash-x",
   ZAI_GLM_4_6: "zai:glm-4-6",
   ZAI_GLM_4_5: "zai:glm-4-5",
+  ZAI_GLM_4_5_X: "zai:glm-4-5-x",
   ZAI_GLM_4_5_AIR: "zai:glm-4-5-air",
   ZAI_GLM_4_5_AIR_X: "zai:glm-4-5-air-x",
-  // Alibaba (Qwen via DashScope)
+  // Alibaba (Qwen via DashScope, international/Singapore deployment)
+  ALIBABA_QWEN3_6_MAX_PREVIEW: "alibaba:qwen3.6-max-preview",
+  ALIBABA_QWEN3_6_PLUS: "alibaba:qwen3.6-plus",
+  ALIBABA_QWEN3_6_FLASH: "alibaba:qwen3.6-flash",
   ALIBABA_QWEN3_MAX: "alibaba:qwen3-max",
   ALIBABA_QWEN3_5_PLUS: "alibaba:qwen3.5-plus",
+  ALIBABA_QWEN3_5_FLASH: "alibaba:qwen3.5-flash",
   ALIBABA_QWEN_PLUS: "alibaba:qwen-plus",
   ALIBABA_QWEN_FLASH: "alibaba:qwen-flash",
   ALIBABA_QWQ_PLUS: "alibaba:qwq-plus",
@@ -112,41 +125,41 @@ const MODEL_CONFIG_RAW: Record<ModelAliasKey, ModelConfigEntry> = {
     tokenCostInPerMillion: 0.1,
     tokenCostOutPerMillion: 0.4,
   },
-  "openai:gpt-4o": {
+  "openai:gpt-5.4": {
     provider: "openai",
-    model: "gpt-4o",
+    model: "gpt-5.4",
     tokenCostInPerMillion: 2.5,
-    tokenCostOutPerMillion: 10,
+    tokenCostOutPerMillion: 15,
   },
-  "openai:gpt-4o-mini": {
+  "openai:gpt-5.4-mini": {
     provider: "openai",
-    model: "gpt-4o-mini",
-    tokenCostInPerMillion: 0.15,
-    tokenCostOutPerMillion: 0.6,
+    model: "gpt-5.4-mini",
+    tokenCostInPerMillion: 0.75,
+    tokenCostOutPerMillion: 4.5,
   },
-  "openai:gpt-5.2": {
+  "openai:gpt-5.4-nano": {
     provider: "openai",
-    model: "gpt-5.2",
-    tokenCostInPerMillion: 2,
-    tokenCostOutPerMillion: 10,
+    model: "gpt-5.4-nano",
+    tokenCostInPerMillion: 0.2,
+    tokenCostOutPerMillion: 1.25,
   },
-  "openai:gpt-5.2-pro": {
+  "openai:gpt-5.5": {
     provider: "openai",
-    model: "gpt-5.2-pro",
-    tokenCostInPerMillion: 15,
-    tokenCostOutPerMillion: 60,
+    model: "gpt-5.5",
+    tokenCostInPerMillion: 5,
+    tokenCostOutPerMillion: 30,
+  },
+  "openai:gpt-5.5-pro": {
+    provider: "openai",
+    model: "gpt-5.5-pro",
+    tokenCostInPerMillion: 30,
+    tokenCostOutPerMillion: 180,
   },
   "openai:o3": {
     provider: "openai",
     model: "o3",
-    tokenCostInPerMillion: 10,
-    tokenCostOutPerMillion: 40,
-  },
-  "openai:o3-mini": {
-    provider: "openai",
-    model: "o3-mini",
-    tokenCostInPerMillion: 1.1,
-    tokenCostOutPerMillion: 4.4,
+    tokenCostInPerMillion: 2,
+    tokenCostOutPerMillion: 8,
   },
   "openai:o4-mini": {
     provider: "openai",
@@ -185,13 +198,13 @@ const MODEL_CONFIG_RAW: Record<ModelAliasKey, ModelConfigEntry> = {
     tokenCostInPerMillion: 3,
     tokenCostOutPerMillion: 15,
   },
-  "anthropic:haiku-4-6": {
+  "anthropic:opus-4-7": {
     provider: "anthropic",
-    model: "claude-haiku-4-6",
-    tokenCostInPerMillion: 1,
-    tokenCostOutPerMillion: 5,
+    model: "claude-opus-4-7",
+    tokenCostInPerMillion: 5,
+    tokenCostOutPerMillion: 25,
   },
-  // Gemini
+  // Gemini — base (≤200k context) pricing for tiered models
   "gemini:flash-2.5": {
     provider: "gemini",
     model: "gemini-2.5-flash",
@@ -210,31 +223,49 @@ const MODEL_CONFIG_RAW: Record<ModelAliasKey, ModelConfigEntry> = {
     tokenCostInPerMillion: 1.25,
     tokenCostOutPerMillion: 10,
   },
+  "gemini:pro-3.1-preview": {
+    provider: "gemini",
+    model: "gemini-3.1-pro-preview",
+    tokenCostInPerMillion: 2,
+    tokenCostOutPerMillion: 12,
+  },
+  "gemini:flash-3-preview": {
+    provider: "gemini",
+    model: "gemini-3-flash-preview",
+    tokenCostInPerMillion: 0.5,
+    tokenCostOutPerMillion: 3,
+  },
+  "gemini:flash-3.1-lite-preview": {
+    provider: "gemini",
+    model: "gemini-3.1-flash-lite-preview",
+    tokenCostInPerMillion: 0.25,
+    tokenCostOutPerMillion: 1.5,
+  },
   // DeepSeek — cache miss prices
-  "deepseek:deepseek-chat": {
+  "deepseek:v4-flash": {
     provider: "deepseek",
-    model: "deepseek-chat",
-    tokenCostInPerMillion: 0.28,
-    tokenCostOutPerMillion: 0.42,
+    model: "deepseek-v4-flash",
+    tokenCostInPerMillion: 0.14,
+    tokenCostOutPerMillion: 0.28,
   },
-  "deepseek:deepseek-reasoner": {
+  "deepseek:v4-pro": {
     provider: "deepseek",
-    model: "deepseek-reasoner",
-    tokenCostInPerMillion: 0.28,
-    tokenCostOutPerMillion: 0.42,
+    model: "deepseek-v4-pro",
+    tokenCostInPerMillion: 1.74,
+    tokenCostOutPerMillion: 3.48,
   },
-  // Moonshot / Kimi
+  // Moonshot / Kimi — cache miss prices
   "moonshot:kimi-k2.5": {
     provider: "moonshot",
     model: "kimi-k2.5",
-    tokenCostInPerMillion: 0.5,
+    tokenCostInPerMillion: 0.6,
     tokenCostOutPerMillion: 2.5,
   },
-  "moonshot:kimi-k1.5": {
+  "moonshot:kimi-k2.6": {
     provider: "moonshot",
-    model: "kimi-k1.5",
-    tokenCostInPerMillion: 0.5,
-    tokenCostOutPerMillion: 2.5,
+    model: "kimi-k2.6",
+    tokenCostInPerMillion: 0.95,
+    tokenCostOutPerMillion: 4,
   },
   // Claude Code — subscription-based, zero token cost
   "claude-code:sonnet": {
@@ -256,17 +287,23 @@ const MODEL_CONFIG_RAW: Record<ModelAliasKey, ModelConfigEntry> = {
     tokenCostOutPerMillion: 0,
   },
   // Z.ai
+  "zai:glm-5-1": {
+    provider: "zai",
+    model: "glm-5.1",
+    tokenCostInPerMillion: 1.4,
+    tokenCostOutPerMillion: 4.4,
+  },
   "zai:glm-5": {
     provider: "zai",
     model: "glm-5",
     tokenCostInPerMillion: 1,
     tokenCostOutPerMillion: 3.2,
   },
-  "zai:glm-5-code": {
+  "zai:glm-5-turbo": {
     provider: "zai",
-    model: "glm-5-code",
+    model: "glm-5-turbo",
     tokenCostInPerMillion: 1.2,
-    tokenCostOutPerMillion: 5,
+    tokenCostOutPerMillion: 4,
   },
   "zai:glm-4-7": {
     provider: "zai",
@@ -292,6 +329,12 @@ const MODEL_CONFIG_RAW: Record<ModelAliasKey, ModelConfigEntry> = {
     tokenCostInPerMillion: 0.6,
     tokenCostOutPerMillion: 2.2,
   },
+  "zai:glm-4-5-x": {
+    provider: "zai",
+    model: "glm-4.5-x",
+    tokenCostInPerMillion: 2.2,
+    tokenCostOutPerMillion: 8.9,
+  },
   "zai:glm-4-5-air": {
     provider: "zai",
     model: "glm-4.5-air",
@@ -304,30 +347,54 @@ const MODEL_CONFIG_RAW: Record<ModelAliasKey, ModelConfigEntry> = {
     tokenCostInPerMillion: 1.1,
     tokenCostOutPerMillion: 4.5,
   },
-  // Alibaba (Qwen via DashScope)
+  // Alibaba (Qwen via DashScope, international/Singapore deployment, base tier)
+  "alibaba:qwen3.6-max-preview": {
+    provider: "alibaba",
+    model: "qwen3.6-max-preview",
+    tokenCostInPerMillion: 1.3,
+    tokenCostOutPerMillion: 7.8,
+  },
+  "alibaba:qwen3.6-plus": {
+    provider: "alibaba",
+    model: "qwen3.6-plus",
+    tokenCostInPerMillion: 0.276,
+    tokenCostOutPerMillion: 1.651,
+  },
+  "alibaba:qwen3.6-flash": {
+    provider: "alibaba",
+    model: "qwen3.6-flash",
+    tokenCostInPerMillion: 0.025,
+    tokenCostOutPerMillion: 1.5,
+  },
   "alibaba:qwen3-max": {
     provider: "alibaba",
     model: "qwen3-max",
-    tokenCostInPerMillion: 0.359,
-    tokenCostOutPerMillion: 1.434,
+    tokenCostInPerMillion: 1.2,
+    tokenCostOutPerMillion: 6,
   },
   "alibaba:qwen3.5-plus": {
     provider: "alibaba",
     model: "qwen3.5-plus",
-    tokenCostInPerMillion: 0.115,
-    tokenCostOutPerMillion: 0.688,
+    tokenCostInPerMillion: 0.4,
+    tokenCostOutPerMillion: 2.4,
+  },
+  "alibaba:qwen3.5-flash": {
+    provider: "alibaba",
+    model: "qwen3.5-flash",
+    tokenCostInPerMillion: 0.1,
+    tokenCostOutPerMillion: 0.4,
   },
   "alibaba:qwen-plus": {
     provider: "alibaba",
     model: "qwen-plus",
-    tokenCostInPerMillion: 0.115,
-    tokenCostOutPerMillion: 0.287,
+    tokenCostInPerMillion: 0.4,
+    tokenCostOutPerMillion: 1.2,
   },
   "alibaba:qwen-flash": {
     provider: "alibaba",
     model: "qwen-flash",
-    tokenCostInPerMillion: 0.022,
-    tokenCostOutPerMillion: 0.216,
+    tokenCostInPerMillion: 0.05,
+    tokenCostOutPerMillion: 0.4,
   },
   "alibaba:qwq-plus": {
     provider: "alibaba",
@@ -338,19 +405,21 @@ const MODEL_CONFIG_RAW: Record<ModelAliasKey, ModelConfigEntry> = {
   "alibaba:qwen3-coder-plus": {
     provider: "alibaba",
     model: "qwen3-coder-plus",
-    tokenCostInPerMillion: 0.574,
-    tokenCostOutPerMillion: 2.294,
+    tokenCostInPerMillion: 1,
+    tokenCostOutPerMillion: 5,
   },
   "alibaba:qwen3-coder-flash": {
     provider: "alibaba",
     model: "qwen3-coder-flash",
-    tokenCostInPerMillion: 0.144,
-    tokenCostOutPerMillion: 0.574,
+    tokenCostInPerMillion: 0.3,
+    tokenCostOutPerMillion: 1.5,
   },
 };
 
 export const MODEL_CONFIG: Readonly<Record<ModelAliasKey, ModelConfigEntry>> =
-  deepFreeze(MODEL_CONFIG_RAW) as Readonly<Record<ModelAliasKey, ModelConfigEntry>>;
+  deepFreeze(MODEL_CONFIG_RAW) as Readonly<
+    Record<ModelAliasKey, ModelConfigEntry>
+  >;
 
 export const VALID_MODEL_ALIASES: ReadonlySet<ModelAliasKey> = new Set(
   Object.keys(MODEL_CONFIG) as ModelAliasKey[],
@@ -360,18 +429,24 @@ export const VALID_MODEL_ALIASES: ReadonlySet<ModelAliasKey> = new Set(
 
 export function aliasToFunctionName(alias: string): string {
   if (typeof alias !== "string") {
-    throw new Error(`Invalid model alias: expected string, got ${typeof alias}`);
+    throw new Error(
+      `Invalid model alias: expected string, got ${typeof alias}`,
+    );
   }
   if (!alias.includes(":")) {
     throw new Error(`Invalid model alias: "${alias}" does not contain a colon`);
   }
   const model = alias.split(":").slice(1).join(":");
-  return model.replace(/[-.]([a-z0-9])/gi, (_, char: string) => char.toUpperCase());
+  return model.replace(/[-.]([a-z0-9])/gi, (_, char: string) =>
+    char.toUpperCase(),
+  );
 }
 
 export function getProviderFromAlias(alias: string): ProviderName {
   if (typeof alias !== "string") {
-    throw new Error(`Invalid model alias: expected string, got ${typeof alias}`);
+    throw new Error(
+      `Invalid model alias: expected string, got ${typeof alias}`,
+    );
   }
   if (!alias.includes(":")) {
     throw new Error(`Invalid model alias: "${alias}" does not contain a colon`);
@@ -381,7 +456,9 @@ export function getProviderFromAlias(alias: string): ProviderName {
 
 export function getModelFromAlias(alias: string): string {
   if (typeof alias !== "string") {
-    throw new Error(`Invalid model alias: expected string, got ${typeof alias}`);
+    throw new Error(
+      `Invalid model alias: expected string, got ${typeof alias}`,
+    );
   }
   if (!alias.includes(":")) {
     throw new Error(`Invalid model alias: "${alias}" does not contain a colon`);
@@ -390,33 +467,38 @@ export function getModelFromAlias(alias: string): string {
 }
 
 export function getModelConfig(alias: string): ModelConfigEntry | null {
-  return (MODEL_CONFIG as Record<string, ModelConfigEntry | undefined>)[alias] ?? null;
+  return (
+    (MODEL_CONFIG as Record<string, ModelConfigEntry | undefined>)[alias] ??
+    null
+  );
 }
 
 // ─── Default Model By Provider ───────────────────────────────────────────────
 
-export const DEFAULT_MODEL_BY_PROVIDER: Readonly<Record<ProviderName, ModelAliasKey>> =
-  Object.freeze({
-    openai: "openai:gpt-5.2",
-    anthropic: "anthropic:sonnet-4-6",
-    gemini: "gemini:flash-2.5",
-    deepseek: "deepseek:deepseek-chat",
-    moonshot: "moonshot:kimi-k2.5",
-    "claude-code": "claude-code:sonnet",
-    zai: "zai:glm-5",
-    alibaba: "alibaba:qwen3-max",
-  } as const);
+export const DEFAULT_MODEL_BY_PROVIDER: Readonly<
+  Record<ProviderName, ModelAliasKey>
+> = Object.freeze({
+  openai: "openai:gpt-5.4",
+  anthropic: "anthropic:sonnet-4-6",
+  gemini: "gemini:flash-2.5",
+  deepseek: "deepseek:v4-flash",
+  moonshot: "moonshot:kimi-k2.6",
+  "claude-code": "claude-code:sonnet",
+  zai: "zai:glm-5-1",
+  alibaba: "alibaba:qwen3-max",
+} as const);
 
 // ─── Function Name Derived Index ─────────────────────────────────────────────
 
-export const FUNCTION_NAME_BY_ALIAS: Readonly<Record<ModelAliasKey, string>> = Object.freeze(
-  Object.fromEntries(
-    (Object.keys(MODEL_CONFIG) as ModelAliasKey[]).map((alias) => [
-      alias,
-      aliasToFunctionName(alias),
-    ]),
-  ) as Record<ModelAliasKey, string>,
-);
+export const FUNCTION_NAME_BY_ALIAS: Readonly<Record<ModelAliasKey, string>> =
+  Object.freeze(
+    Object.fromEntries(
+      (Object.keys(MODEL_CONFIG) as ModelAliasKey[]).map((alias) => [
+        alias,
+        aliasToFunctionName(alias),
+      ]),
+    ) as Record<ModelAliasKey, string>,
+  );
 
 // ─── Provider Functions Index ────────────────────────────────────────────────
 
@@ -438,7 +520,13 @@ export function buildProviderFunctionsIndex(): ProviderFunctionsIndex {
       index[provider] = [];
     }
     index[provider]!.push(
-      Object.freeze({ alias, provider, model, functionName, fullPath }) as ProviderFunctionEntry,
+      Object.freeze({
+        alias,
+        provider,
+        model,
+        functionName,
+        fullPath,
+      }) as ProviderFunctionEntry,
     );
   }
 
@@ -450,7 +538,8 @@ export function buildProviderFunctionsIndex(): ProviderFunctionsIndex {
   return Object.freeze(index) as ProviderFunctionsIndex;
 }
 
-export const PROVIDER_FUNCTIONS: ProviderFunctionsIndex = buildProviderFunctionsIndex();
+export const PROVIDER_FUNCTIONS: ProviderFunctionsIndex =
+  buildProviderFunctionsIndex();
 
 // ─── Module-Load Invariant Validation ────────────────────────────────────────
 
@@ -497,13 +586,19 @@ export function validateModelRegistry(
     }
 
     // Check non-negative token costs
-    if (typeof entry.tokenCostInPerMillion !== "number" || entry.tokenCostInPerMillion < 0) {
+    if (
+      typeof entry.tokenCostInPerMillion !== "number" ||
+      entry.tokenCostInPerMillion < 0
+    ) {
       throw new Error(
         `Model config invariant violation: alias "${alias}" has invalid tokenCostInPerMillion: ` +
           `${entry.tokenCostInPerMillion}`,
       );
     }
-    if (typeof entry.tokenCostOutPerMillion !== "number" || entry.tokenCostOutPerMillion < 0) {
+    if (
+      typeof entry.tokenCostOutPerMillion !== "number" ||
+      entry.tokenCostOutPerMillion < 0
+    ) {
       throw new Error(
         `Model config invariant violation: alias "${alias}" has invalid tokenCostOutPerMillion: ` +
           `${entry.tokenCostOutPerMillion}`,


### PR DESCRIPTION
## Summary
- bring forward the model registry updates from the unmerged rpm-model-update-apir-26 branch
- add Alibaba Qwen 3.6 Flash and Qwen 3.6 Max Preview alongside Qwen 3.6 Plus
- update registry tests for the refreshed model count, removed aliases, and generated Alibaba Qwen 3.6 callable paths

## Validation
- bun test src/config/__tests__/models.test.ts
- bun run typecheck