### PR TITLE
fix(core): add grace window to stale slot pruning to protect in-flight acquisitions (#285)

### DIFF
--- a/src/core/__tests__/job-concurrency.test.ts
+++ b/src/core/__tests__/job-concurrency.test.ts
@@ -197,14 +197,14 @@ describe("pruneStaleJobSlots", () => {
     }
   });
 
-  test("removes and reports lease whose current/<jobId> directory is missing", async () => {
+  test("removes and reports lease whose current/<jobId> directory is missing once aged past lockTimeoutMs", async () => {
     const dir = await mkdtemp(join(tmpdir(), "prune-stale-"));
     const { runningJobsDir } = getConcurrencyRuntimePaths(dir);
     await mkdir(runningJobsDir, { recursive: true });
     const slotPath = await writeLease(runningJobsDir, "job-missing", {
       jobId: "job-missing",
       pid: process.pid,
-      acquiredAt: new Date().toISOString(),
+      acquiredAt: new Date(Date.now() - 60_000).toISOString(),
       source: "orchestrator",
       slotPath: join(runningJobsDir, "job-missing.json"),
     });
@@ -214,6 +214,29 @@ describe("pruneStaleJobSlots", () => {
         { jobId: "job-missing", slotPath, reason: "missing_current_job" },
       ]);
       expect(existsSync(slotPath)).toBe(false);
+    } finally {
+      await rm(dir, { recursive: true });
+    }
+  });
+
+  test("does not prune a fresh lease whose current/<jobId> dir has not yet been created", async () => {
+    // drainPendingQueue acquires the slot before creating current/<jobId>.
+    // A pruner running in that window must not delete the in-flight lease,
+    // or the global concurrency cap can be bypassed.
+    const dir = await mkdtemp(join(tmpdir(), "prune-stale-"));
+    const { runningJobsDir } = getConcurrencyRuntimePaths(dir);
+    await mkdir(runningJobsDir, { recursive: true });
+    const slotPath = await writeLease(runningJobsDir, "job-inflight", {
+      jobId: "job-inflight",
+      pid: process.pid,
+      acquiredAt: new Date().toISOString(),
+      source: "orchestrator",
+      slotPath: join(runningJobsDir, "job-inflight.json"),
+    });
+    try {
+      const result = await pruneStaleJobSlots(dir, 60_000);
+      expect(result).toEqual([]);
+      expect(existsSync(slotPath)).toBe(true);
     } finally {
       await rm(dir, { recursive: true });
     }

--- a/src/core/__tests__/orchestrator.test.ts
+++ b/src/core/__tests__/orchestrator.test.ts
@@ -227,7 +227,10 @@ describe("drainPendingQueue", () => {
       expect(killed).toBe(1);
       expect(existsSync(join(dir, "pending", "job-pid-fail-seed.json"))).toBe(true);
       await rm(lockDir, { recursive: true, force: true });
-      const status = await getJobConcurrencyStatus(dir, 2, 1000);
+      // The lease's missing_current_job grace window (lockTimeoutMs) must elapse
+      // before status-driven pruning will reclaim the slot.
+      await new Promise((r) => setTimeout(r, 30));
+      const status = await getJobConcurrencyStatus(dir, 2, 10);
       expect(status.activeJobs).toEqual([]);
     } finally {
       await rm(dir, { recursive: true });

--- a/src/core/job-concurrency.ts
+++ b/src/core/job-concurrency.ts
@@ -161,12 +161,16 @@ async function classifyLease(
     return { jobId: fallbackJobId, slotPath, reason: "invalid_json" };
   }
   const jobId = typeof parsed.jobId === "string" ? parsed.jobId : fallbackJobId;
+  const acquiredMs = Date.parse(parsed.acquiredAt);
+  const leaseAgedOut = !Number.isFinite(acquiredMs) || Date.now() - acquiredMs >= lockTimeoutMs;
   if (!(await directoryExists(join(dataDir, "current", jobId)))) {
+    // Grace window: drainPendingQueue acquires the slot before creating
+    // current/<jobId>, so a fresh lease without a current dir is in-flight, not stale.
+    if (!leaseAgedOut) return null;
     return { jobId, slotPath, reason: "missing_current_job" };
   }
-  const acquiredMs = Date.parse(parsed.acquiredAt);
   if (parsed.pid === null || parsed.pid === undefined) {
-    if (!Number.isFinite(acquiredMs) || Date.now() - acquiredMs >= lockTimeoutMs) {
+    if (leaseAgedOut) {
       return { jobId, slotPath, reason: "missing_pid" };
     }
     return null;


### PR DESCRIPTION
## Summary

Fixes a race condition in stale slot pruning where `pruneStaleJobSlots` could reap a lease that `drainPendingQueue` just acquired but hasn't yet created `current/<jobId>` for.

### Changes
- `classifyLease` now checks the `missing_current_job` case against a grace window (`lockTimeoutMs`): fresh leases without a current dir are treated as in-flight rather than stale
- Added test for fresh lease with no current dir not being pruned
- Updated "missing current job" test to use an aged lease
- Fixed orchestrator PID update failure test to account for the grace window

Closes #285